### PR TITLE
refactor(auth): enhance middleware and sign-in flow

### DIFF
--- a/components/pages/auth/Signin/index.tsx
+++ b/components/pages/auth/Signin/index.tsx
@@ -2,7 +2,6 @@ import { useState, Fragment } from "react";
 import { useForm, SubmitHandler } from "react-hook-form";
 import { useDispatch } from "react-redux";
 import { setUser } from "@/utils/redux/slices/user";
-import { useRouter } from "next/router";
 import { LoaderSpinner } from "@/components/ui/LoaderSpinner";
 import FormField from "@/utils/react-hook-form/FloatingLabel";
 import { RegisterField } from "@/utils/react-hook-form/types";
@@ -39,7 +38,6 @@ const Signin: React.FC = () => {
   });
 
   const [showPassword, setShowPassword] = useState(false);
-  const router = useRouter();
   const theme = useTheme();
 
   const onSubmit: SubmitHandler<SignInInputs> = async (data) => {
@@ -53,13 +51,11 @@ const Signin: React.FC = () => {
 
     const result = await res.json();
 
-    console.log("result", result);
-
     if (Object.is(result.error, null)) {
       switch (result.statusCode) {
         case 200:
           result.data && dispatch(setUser(result.data));
-          router.push("/user/profile");
+          window.location.href = "/user/profile";
           break;
         case 404:
           setError("email", { type: "manual", message: "帳號或密碼錯誤" });

--- a/middleware.tsx
+++ b/middleware.tsx
@@ -1,122 +1,36 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
-import { get_auth_check } from "@/constants/apiPath";
+import { check } from "@/utils/api/auth/check";
+import { isValid } from "@/helpers/api/status";
 
 /** TBD: 後續邏輯
  *    - 驗證 Token 的有效性：Middleware 中使用 JWT 驗證來確認 token 是否有效 (jose)
  */
 
-console.log(
-  "process.env.NEXT_PUBLIC_NODE_ENV:",
-  process.env.NEXT_PUBLIC_NODE_ENV,
-);
+export const config = {
+  matcher: ["/user/:path", "/cart", "/cart/:path*", "/inquiry"],
+};
 
-export function middleware(request: NextRequest) {
-  let cookie = request.cookies.get("nextjs");
-  console.log("middleware cookie 頭:", cookie);
-  // const token = request.cookies.get("token");
-  // console.log("middleware token:", token); // => { name: 'nextjs', value: 'fast', Path: '/' }
-  const allCookies = request.cookies.getAll();
-  console.log("middleware allCookies:", allCookies); // => [{ name: 'nextjs', value: 'fast' }]
-
-  const hasToken = allCookies.some((cookie) => cookie.name === "token");
-  console.log("是否存在 token cookie:", hasToken);
-  if (hasToken) {
-    const tokenCookie = allCookies.find((cookie) => cookie.name === "token");
-    console.log("tokenCookie:", tokenCookie);
-    const isValidTokenValue =
-      tokenCookie?.value && tokenCookie.value.length > 0;
-    console.log("token 值是否有效:", isValidTokenValue);
-
-    if (!isValidTokenValue) {
-      console.log("token 存在但沒有有效值");
-      // 這裡可以添加處理無效 token 的邏輯
-    }
-  }
-
+export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
+  const token = request.cookies.get("token");
+  console.log(`middleware start ${pathname} token: ${token}`);
 
-  if (pathname.startsWith("/cart")) {
-    const tokenCookie = allCookies.find((cookie) => cookie.name === "token");
-    console.log(
-      "middleware pathname:",
-      pathname,
-      tokenCookie,
-      request.cookies.has("token"),
-    );
-    const isValidTokenValue =
-      tokenCookie?.value && tokenCookie.value.length > 0;
-    if (!isValidTokenValue) {
-      console.log("middleware 跳轉到登入頁");
+  if (pathname.startsWith("/cart") || pathname.startsWith("/user")) {
+    console.log(`middleware ${pathname} token: ${token}`);
+
+    if (!token) {
       return NextResponse.redirect(new URL("/auth/signin", request.url));
     }
 
-    const response = NextResponse.next();
-    cookie = response.cookies.get("token");
-    console.log("middleware cookie 尾:", cookie);
-    return response;
+    const authResponse = await check(token.value);
+
+    if (isValid(authResponse)) {
+      return NextResponse.next();
+    } else {
+      return NextResponse.redirect(new URL("/auth/signin", request.url));
+    }
   }
 
-  // console.log(`middleware ${pathname} 驗證通過`);
-
-  // Setting cookies on the response using the `ResponseCookies` API
-  const response = NextResponse.next();
-  response.cookies.set("vercel", "fast");
-  response.cookies.set({
-    name: "vercel",
-    value: "fast",
-    path: "/",
-  });
-  cookie = response.cookies.get("vercel");
-  console.log("middleware cookie 外:", cookie);
-  return response;
+  return NextResponse.next();
 }
-
-// export async function middleware(request: NextRequest) {
-//   const { pathname } = request.nextUrl;
-//   console.log("middleware 執行", pathname);
-//   const token = request.cookies.get("token");
-
-//   if (pathname.startsWith("/cart") || pathname.startsWith("/user")) {
-//     console.log("middleware token:", token);
-//     if (!token) {
-//       return NextResponse.redirect(new URL("/auth/signin", request.url));
-//     }
-
-//     const authResponse = await fetch(get_auth_check, {
-//       method: "POST",
-//       headers: {
-//         Authorization: `Bearer ${token.value}`,
-//         Accept: "application/json",
-//         "Content-Type": "application/json",
-//       },
-//     });
-
-//     console.log("Auth check response:", {
-//       status: authResponse.status,
-//       ok: authResponse.ok,
-//     });
-
-//     switch (authResponse.status) {
-//       case 200:
-//         return NextResponse.next();
-//       case 401:
-//         return NextResponse.redirect(new URL("/auth/signin", request.url));
-//       default:
-//         return NextResponse.redirect(new URL("/auth/signin", request.url));
-//     }
-//   }
-
-//   return NextResponse.next();
-// }
-// if (pathname.startsWith("/inquiry")) {
-
-// }
-
-// export const config = {
-//   matcher: ["/user/:path", "/cart/:path*"],
-// };
-
-export const config = {
-  matcher: ["/user/:path", "/cart", "/cart/:path*"],
-};

--- a/pages/api/auth/signin.ts
+++ b/pages/api/auth/signin.ts
@@ -1,8 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import signIn from "@/utils/api/auth/signin";
-import { setAuthCookie } from "@/helpers/cookies";
 import { isValid } from "@/helpers/api/status";
-import { NODE_ENV } from "@/constants/environment";
+import { setAuthCookie } from "@/helpers/cookies";
 
 export default async function handler(
   req: NextApiRequest,
@@ -13,37 +12,9 @@ export default async function handler(
   const { data, ...rest } = result;
   const { jwtToken, ...userData } = data || {};
 
-  console.log("NODE_ENV:", NODE_ENV);
-  console.log("process.env.NEXT_PUBLIC_NODE_ENV;", process.env.NEXT_PUBLIC_NODE_ENV);
-  console.log("jwtToken:", jwtToken);
-
   if (isValid(rest) && jwtToken) {
-    console.log("設置 cookie 前的驗證：", { jwtToken }); 
-    
-    // 設置 cookie
     const cookieHeader = setAuthCookie(jwtToken);
     res.setHeader("Set-Cookie", cookieHeader);
-    
-    // 驗證 cookie 是否正確設置
-    const setCookieHeader = res.getHeader("Set-Cookie");
-    console.log("Cookie 設置狀態：", {
-      cookieHeader,
-      headerAfterSet: setCookieHeader,
-      isHeaderSet: !!setCookieHeader,
-    });
-
-    // 解析設置的 cookie 內容
-    if (typeof setCookieHeader === 'string' || Array.isArray(setCookieHeader)) {
-      const cookieString = Array.isArray(setCookieHeader) 
-        ? setCookieHeader[0] 
-        : setCookieHeader;
-      
-      console.log("已設置的 Cookie 內容：", {
-        cookieString,
-        containsToken: cookieString.includes('token='),
-        cookieLength: cookieString.length
-      });
-    }
   }
 
   return res.json({

--- a/utils/api/postOrder.tsx
+++ b/utils/api/postOrder.tsx
@@ -22,6 +22,8 @@ export const postOrder = async (
 
   const [res, error] = await catchError(fetch(parsedUrl, options));
 
+  console.log("res", res, error);
+
   if (error) {
     console.log("error", error);
 


### PR DESCRIPTION
# 暫時解決 production 環境，登入後沒有跳轉到需要驗證的頁面
[refactor(auth): enhance middleware and sign-in flow](https://github.com/kentrpg/assist-hub/commit/982ed9bdf9cb1c54decd44d26174e55cca694ff8)


## 短解
- components/pages/auth/Signin/index.tsx 元件內 onSubmit event handle 跳轉方式改為 window.location.href = "/user/profile";。

## 問題原因
在 production 環境中，next/router 的 router.push("user/profile") 被當作是內部跳轉（Client-Side Navigation），這種跳轉不會觸發新的 HTTP 請求，因此 middleware 不會執行，也無法驗證更新後的 token，導致會驗證失敗一直跳轉到登入頁面。