### PR TITLE
Refactor linepay api query

### DIFF
--- a/components/pages/cart/Checkout/index.tsx
+++ b/components/pages/cart/Checkout/index.tsx
@@ -66,6 +66,7 @@ import { Loading } from "@/components/ui/Loading";
 import { RootState } from "@/utils/redux/store";
 import { isValid, hasError } from "@/helpers/api/status";
 import { setLinePay } from "@/utils/redux/slices/linePay";
+import { BASE_URL, BASE_URL_VM, NODE_ENV } from "@/constants/environment";
 
 const Checkout = () => {
   const dispatch = useDispatch();
@@ -134,7 +135,9 @@ const Checkout = () => {
     console.log("Form submitted:", data);
     setIsOrderSubmitting(true);
 
+    const confirmUrl = NODE_ENV === "development" ? BASE_URL : BASE_URL_VM;
     const checkoutData = {
+      confirmUrl: `${confirmUrl}/cart/checkout/confirm`,
       product: {
         id: cart.cartId,
         name: cart.name,

--- a/components/pages/cart/Checkout/index.tsx
+++ b/components/pages/cart/Checkout/index.tsx
@@ -135,9 +135,8 @@ const Checkout = () => {
     console.log("Form submitted:", data);
     setIsOrderSubmitting(true);
 
-    const confirmUrl = NODE_ENV === "development" ? BASE_URL : BASE_URL_VM;
     const checkoutData = {
-      confirmUrl: `${confirmUrl}/cart/checkout/confirm`,
+      confirmUrl: `${BASE_URL}/cart/checkout/confirm`,
       product: {
         id: cart.cartId,
         name: cart.name,

--- a/middleware.tsx
+++ b/middleware.tsx
@@ -8,7 +8,12 @@ import { isValid } from "@/helpers/api/status";
  */
 
 export const config = {
-  matcher: ["/user/:path", "/cart", "/cart/:path*", "/inquiry"],
+  matcher: [
+    "/user/:path*",
+    "/cart",
+    "/cart/((?!checkout/confirm).)*",
+    "/inquiry",
+  ],
 };
 
 export async function middleware(request: NextRequest) {

--- a/pages/api/line/getLinepayConfirm.tsx
+++ b/pages/api/line/getLinepayConfirm.tsx
@@ -2,19 +2,20 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { Result } from "@/types/postOrder";
 import getLinepayConfirm from "@/utils/api/line/getLinepayConfirm";
 import { validateMethod } from "@/helpers/api/validateMethod";
+import { RequestGetLinepayConfirmQueryType } from "@/types/getLinepayConfirm";
 
 export default async function handler(
-  req: NextApiRequest,
+  req: NextApiRequest & { query: RequestGetLinepayConfirmQueryType },
   res: NextApiResponse<Result>,
 ) {
   const methodError = await validateMethod("GET")(req, res);
   if (methodError) return methodError;
 
-  const { transactionId, finalAmount } = req.query;
+  const { transactionId, orderId } = req.query;
 
   const result = await getLinepayConfirm({
-    transactionId: transactionId as string,
-    finalAmount: finalAmount as string,
+    transactionId,
+    orderId: Number(orderId),
   });
 
   return res.json(result);

--- a/pages/cart/checkout/confirm.tsx
+++ b/pages/cart/checkout/confirm.tsx
@@ -42,8 +42,6 @@ const ConfirmPage = () => {
         setPaymentResult(result);
         console.log("result", result);
 
-        // isValid(result) && setPaymentStatus("success");
-
         switch (result.statusCode) {
           case 200:
             setPaymentStatus("success");

--- a/types/getLinepayConfirm.ts
+++ b/types/getLinepayConfirm.ts
@@ -1,8 +1,13 @@
 import { Error } from "@/types/apiRoutes";
 
+export type RequestGetLinepayConfirmQueryType = {
+  transactionId: string;
+  orderId: string;
+};
+
 export type RequestGetLinepayConfirmType = {
   transactionId: string;
-  finalAmount: string;
+  orderId: number;
 };
 
 export const ResultGetLinepayConfirm = {

--- a/types/postLinepayConfirm.ts
+++ b/types/postLinepayConfirm.ts
@@ -2,7 +2,7 @@ import { Error } from "@/types/apiRoutes";
 
 export type RequestPostLinepayConfirmType = {
   transactionId: string;
-  finalAmount: string;
+  orderId: number;
 };
 
 export const ResultPostLinepayConfirm = {

--- a/types/postOrder.ts
+++ b/types/postOrder.ts
@@ -21,7 +21,8 @@ export type Result<T = unknown> = {
   error?: Error | null;
 };
 
-export const ResultCheckout = {
+export const RequestCheckout = {
+  "confirmUrl": "url",
   "product": {
     "id": 20,
     "name": "鋁製躺式輪椅",
@@ -51,4 +52,4 @@ export const ResultCheckout = {
   }
 };
 
-export type ResultCheckoutType = typeof ResultCheckout;
+export type RequestCheckoutType = typeof RequestCheckout;

--- a/utils/api/line/getLinepayConfirm.tsx
+++ b/utils/api/line/getLinepayConfirm.tsx
@@ -12,8 +12,11 @@ import {
 export const getLinepayConfirm = async (
   data: RequestGetLinepayConfirmType,
 ): Promise<ResultGetLinepayConfirmType> => {
-  const { transactionId, finalAmount } = data;
-  const isMissingRequiredParams = !transactionId || !finalAmount;
+  const { transactionId, orderId } = data;
+  const isMissingRequiredParams = !transactionId || !orderId;
+
+  console.log("transactionId", transactionId);
+  console.log("orderId", orderId);
 
   if (isMissingRequiredParams) {
     return {
@@ -28,7 +31,7 @@ export const getLinepayConfirm = async (
     };
   }
 
-  console.log("data", data);
+  console.log("getLinepayConfirm data", data);
   const parsedUrl = new URL(post_linepay_confirm);
   const options = {
     method: "POST",

--- a/utils/api/line/getLinepayConfirm.tsx
+++ b/utils/api/line/getLinepayConfirm.tsx
@@ -20,12 +20,12 @@ export const getLinepayConfirm = async (
 
   if (isMissingRequiredParams) {
     return {
-      statusCode: 500,
+      statusCode: 405,
       status: false,
       message: "缺少必要參數",
       data: undefined,
       error: {
-        code: 500,
+        code: 405,
         message: "缺少 transactionId 或 finalAmount",
       },
     };

--- a/utils/api/line/postLinepayConfirm.tsx
+++ b/utils/api/line/postLinepayConfirm.tsx
@@ -12,7 +12,6 @@ import {
 export const postLinepayConfirm = async (
   data: RequestPostLinepayConfirmType,
 ): Promise<ResultPostLinepayConfirmType> => {
-  console.log("data", data);
   const parsedUrl = new URL(post_linepay_confirm);
   const options = {
     method: "POST",

--- a/utils/api/postOrder.tsx
+++ b/utils/api/postOrder.tsx
@@ -1,4 +1,4 @@
-import { Result, Response, ResultCheckoutType } from "@/types/postOrder";
+import { Result, Response, RequestCheckoutType } from "@/types/postOrder";
 import { catchError } from "../handleErrors";
 import { Error } from "@/types/apiRoutes";
 import { post_orders } from "@/constants/apiPath";
@@ -7,7 +7,7 @@ import { validateResponseType } from "../typeGuards";
 
 export const postOrder = async (
   token: string,
-  data: ResultCheckoutType,
+  data: RequestCheckoutType,
 ): Promise<Result> => {
   const parsedUrl = new URL(post_orders);
   const options = {


### PR DESCRIPTION
# Line Pay 確認網址邏輯優化

## 變更摘要
優化 Line Pay 結帳流程中的確認網址處理邏輯，統一使用 `BASE_URL` 作為基礎網址，提升程式碼可維護性。

## 主要變更
1. 移除 `NODE_ENV` 環境判斷邏輯
2. 統一使用 `BASE_URL` 作為確認頁面基礎網址
3. 簡化 `confirmUrl` 的組合方式
4. 更新 Line Pay 確認 API 參數結構

## 技術細節
### 程式碼變更
```
// 變更前
const confirmUrl = NODE_ENV === "development" ? BASE_URL : BASE_URL_VM;
const checkoutData = {
confirmUrl: ${confirmUrl}/cart/checkout/confirm,
// ...
};
// 變更後
const checkoutData = {
confirmUrl: ${BASE_URL}/cart/checkout/confirm,
// ...
};
```

## 相關文件
- [components/pages/cart/Checkout/index.tsx](https://github.com/kentrpg/assist-hub/commit/a89e50028dfcfd89f72352624f48d608b2df465f#diff-b5349a3a0acc71d7b27ceecb0ca952f6878f9fbcc61aacc386794ab4492e0bd8)

## 測試重點
- [ ] Line Pay 結帳流程完整測試
- [ ] 確認網址在各環境的正確性
- [ ] API 整合測試
  - 確認頁面導向
  - 參數傳遞正確性