### PR TITLE
Feature tooltips UI

### DIFF
--- a/components/pages/product/All/index.tsx
+++ b/components/pages/product/All/index.tsx
@@ -22,6 +22,7 @@ import {
 import { ProductItem, tabsData, radioOptions } from "./data";
 import { MdInfo, MdRadioButtonChecked, MdOutlineCircle } from "react-icons/md";
 import Category from "./Category";
+import Tooltip from "@/components/ui/Tooltip";
 
 type AllProps = {
   products: ProductItem[];
@@ -127,7 +128,7 @@ const All: React.FC<AllProps> = ({ products }) => {
         <LevelWrapper>
           <Level>
             動作功能分級表
-            <MdInfo color="#103F99" size={24} />
+            <Tooltip text="依照活動能力，對應粗大動作功能分級表找到合適輔具。" />
           </Level>
           <Radios>
             {radioOptions.map((option) => (

--- a/components/ui/Tooltip/data.ts
+++ b/components/ui/Tooltip/data.ts
@@ -1,0 +1,3 @@
+export type TooltipProps = {
+  text: string;
+};

--- a/components/ui/Tooltip/index.tsx
+++ b/components/ui/Tooltip/index.tsx
@@ -1,0 +1,18 @@
+import { Wrapper, Container, Icon, Text } from "./styled";
+import { MdInfo } from "react-icons/md";
+import { TooltipProps } from "./data";
+
+const Tooltip: React.FC<TooltipProps> = ({ text }) => {
+  return (
+    <Wrapper>
+      <Icon>
+        <MdInfo size={24} />
+      </Icon>
+      <Container>
+        <Text>{text}</Text>
+      </Container>
+    </Wrapper>
+  );
+};
+
+export default Tooltip;

--- a/components/ui/Tooltip/styled.tsx
+++ b/components/ui/Tooltip/styled.tsx
@@ -39,10 +39,20 @@ export const Icon = styled.button`
   font-size: 0;
   background-color: transparent;
   color: ${({ theme }) => theme.colors.primary};
+  outline: none;
 
-  &:hover + ${Container} {
-    opacity: 1;
-    visibility: visible;
+  @media (hover: hover) {
+    &:hover + ${Container} {
+      opacity: 1;
+      visibility: visible;
+    }
+  }
+
+  @media (hover: none) {
+    &:focus-within + ${Container} {
+      opacity: 1;
+      visibility: visible;
+    }
   }
 `;
 

--- a/components/ui/Tooltip/styled.tsx
+++ b/components/ui/Tooltip/styled.tsx
@@ -1,0 +1,53 @@
+import styled from "styled-components";
+import { ButtonRadiusSmall } from "@/styles/borderRadius";
+
+export const Wrapper = styled.div`
+  position: relative;
+  font-size: 0;
+`;
+
+export const Container = styled.div`
+  width: 200px;
+  height: auto;
+  position: absolute;
+  left: 50%;
+  bottom: 135%;
+  transform: translateX(-50%);
+  ${ButtonRadiusSmall}
+  background-color: ${({ theme }) => theme.colors.infoLight};
+  padding: 12px;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.2s ease-in-out, visibility 0.2s ease-in-out;
+
+  &::after {
+    content: "";
+    width: 0;
+    height: 0;
+    position: absolute;
+    right: 50%;
+    bottom: -8px;
+    border-style: solid;
+    border-width: 8px 8px 0;
+    border-color: ${({ theme }) =>
+      theme.colors.infoLight} transparent transparent;
+    transform: translateX(50%);
+  }
+`;
+
+export const Icon = styled.button`
+  font-size: 0;
+  background-color: transparent;
+  color: ${({ theme }) => theme.colors.primary};
+
+  &:hover + ${Container} {
+    opacity: 1;
+    visibility: visible;
+  }
+`;
+
+export const Text = styled.p`
+  font-size: 12px;
+  font-weight: 400;
+  color: ${({ theme }) => theme.colors.textSecondary};
+`;


### PR DESCRIPTION
# 產品頁面新增互動式提示元件

## 完成項目
1. 建立 Tooltip 元件
   - 實作基礎提示框功能
   - hover 觸發機制
   - 動畫過渡效果
   - 響應式定位

2. 整合產品頁面
   - 應用於分級表說明
   - 優化資訊呈現方式

## 測試項目
- [ ] 提示框觸發機制
- [ ] 動畫效果流暢度
- [ ] 行動裝置支援

## 相關文檔
- `components/ui/Tooltip/`
  - [index.tsx](https://github.com/kentrpg/assist-hub/pull/45/files#diff-02c866f22b03e33293177f2f18ae05c05df28c85d40a1ff1efc24dab69cf2911)
  - [styled.tsx](https://github.com/kentrpg/assist-hub/pull/45/files#diff-35338c98cf732185646b1a9378e581310908c017b28dd7abf23cbb5d3a29d1c1)

- `Tooltip component instance`
  - [components/pages/product/All/index.tsx](https://github.com/kentrpg/assist-hub/pull/45/files#diff-aa547135a5c3432e75361b4be24068f81a477a668311773bda033d431edd4d8b)

- UI issue 討論
  - [動作功能分級表 Tooltip](https://chalk-freedom-ec6.notion.site/Tooltip-d8ead5042fa74a1981235c779c928a53?pvs=4)

## 後續規劃
目前純用 CSS 選擇器 @media (hover: none)、@media (hover: hover) 來設計，只有觸控設備才會有 focus 點擊效果。

單因為使用原生 CSS 語法，在觸控設備中，沒辦法實現點擊 icon 本身就關閉 Tooltip，如果要做到就要在添加 useState 來做狀態切換。