### PR TITLE
Update admin order

### DIFF
--- a/components/pages/admin/Header/index.tsx
+++ b/components/pages/admin/Header/index.tsx
@@ -31,8 +31,8 @@ export const Header = ({ tabs, activeTab, onTabChange }: HeaderProps) => {
       </TabList>
       <TableToolbar>
         <CountGroup>
-          <CountLabel>顯示筆數</CountLabel>
-          <CountSelect>
+          <CountLabel htmlFor="count">顯示筆數</CountLabel>
+          <CountSelect id="count">
             {countSelects.map((count) => (
               <option key={count} value={count}>
                 {count}

--- a/components/pages/admin/Header/styled.tsx
+++ b/components/pages/admin/Header/styled.tsx
@@ -62,7 +62,7 @@ export const CountGroup = styled.div`
   position: relative;
 `;
 
-export const CountLabel = styled.span`
+export const CountLabel = styled.label`
   font-size: 14px;
   color: ${({ theme }) => theme.colors.textMuted};
   margin-right: 10px;

--- a/components/pages/admin/OrderDetails/data.ts
+++ b/components/pages/admin/OrderDetails/data.ts
@@ -1,0 +1,79 @@
+import { ResultGetAdminOrders } from "@/types/getAdminOrders";
+
+export type OrderData = {
+  orderStatus: string;
+  shippingStatus: string;
+  orderCode: string;
+  createdDate: string;
+  createdStamp: string;
+  note: string;
+  shipping: string;
+  shippinginfo: {
+    name: string;
+    phone: string;
+    email: string;
+    address: string;
+    addressZIP: string;
+    addressCity: string;
+    addressDistrict: string;
+    AddressDetail: string;
+  };
+  details: {
+    quantity: number;
+    productName: string;
+    productDes: string;
+    productImgSrc: string;
+    productImgAlt: string;
+    rent: number;
+    deposit: number;
+    fee: number;
+    finalAmount: number;
+    period: number;
+    rentDate: string;
+    rentStamp: string;
+    returnDate: string;
+    returnStamp: string;
+    payment: string;
+  };
+  member: {
+    memberId: number;
+    name: string;
+    email: string;
+    lineId: string;
+    phone: string;
+  };
+};
+
+export type OrderItemType = {
+  productName: string
+  productCode: string
+  rentPeriod: {
+    start: string
+    end: string
+  }
+  amount: {
+    rent: number
+    deposit: number
+    shipping: number
+    total: number
+  }
+  payment: string
+}
+
+export type UserInfoType = {
+  account: string
+  lineId: string
+  phone: string
+}
+
+export type ShippingInfoType = {
+  name: string
+  phone: string
+  email: string
+  address: {
+    zipCode: string
+    city: string
+    district: string
+    detail: string
+  }
+}

--- a/components/pages/admin/OrderDetails/data.ts
+++ b/components/pages/admin/OrderDetails/data.ts
@@ -58,16 +58,16 @@ export type OrderItemType = {
     total: number
   }
   payment: string
-}
+};
 
 export type UserInfoType = {
   account: string
   lineId: string
-  phone: string
-}
+  phone: string;
+};
 
 export type ShippingInfoType = {
-  name: string
+  name: string;
   phone: string
   email: string
   address: {
@@ -76,4 +76,11 @@ export type ShippingInfoType = {
     district: string
     detail: string
   }
-}
+};
+
+export type ToastType = {
+  show: boolean;
+  message: string;
+  type: "success" | "error";
+  isLeaving: boolean;
+};

--- a/components/pages/admin/OrderDetails/data.ts
+++ b/components/pages/admin/OrderDetails/data.ts
@@ -1,5 +1,3 @@
-import { ResultGetAdminOrders } from "@/types/getAdminOrders";
-
 export type OrderData = {
   orderStatus: string;
   shippingStatus: string;
@@ -84,3 +82,5 @@ export type ToastType = {
   type: "success" | "error";
   isLeaving: boolean;
 };
+
+export const quantitySelects = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];

--- a/components/pages/admin/OrderDetails/data.ts
+++ b/components/pages/admin/OrderDetails/data.ts
@@ -5,7 +5,7 @@ export type OrderData = {
   createdDate: string;
   createdStamp: string;
   note: string;
-  shipping: string;
+  shipping: ShippingType;
   shippinginfo: {
     name: string;
     phone: string;
@@ -17,7 +17,7 @@ export type OrderData = {
     AddressDetail: string;
   };
   details: {
-    quantity: number;
+    quantity: QuantityType;
     productName: string;
     productDes: string;
     productImgSrc: string;
@@ -31,7 +31,7 @@ export type OrderData = {
     rentStamp: string;
     returnDate: string;
     returnStamp: string;
-    payment: string;
+    payment: PaymentType;
   };
   member: {
     memberId: number;
@@ -83,4 +83,45 @@ export type ToastType = {
   isLeaving: boolean;
 };
 
-export const quantitySelects = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+export enum Quantity {
+  one = "1",
+  two = "2",
+  three = "3",
+  four = "4",
+  five = "5",
+  six = "6",
+  seven = "7",
+  eight = "8",
+  nine = "9",
+  ten = "10"
+}
+
+export enum Payment {
+  transfer = "transfer",
+  creditCard = "creditCard",
+  linePay = "LinePay"
+}
+
+export enum Shipping {
+  store = "store",
+  delivery = "delivery"
+}
+
+export const quantitySelects = Object.values(Quantity);
+export const paymentSelects = Object.values(Payment);
+export const shippingSelects = Object.values(Shipping);
+
+export type QuantityType = Quantity;
+export type PaymentType = Payment;
+export type ShippingType = Shipping;
+
+export const shippingStatusMapping = {
+  [Shipping.store]: "店取",
+  [Shipping.delivery]: "宅配"
+}
+
+export const paymentStatusMapping = {
+  [Payment.transfer]: "轉帳",
+  [Payment.creditCard]: "信用卡",
+  [Payment.linePay]: "LinePay"
+}

--- a/components/pages/admin/OrderDetails/index.tsx
+++ b/components/pages/admin/OrderDetails/index.tsx
@@ -1,115 +1,188 @@
-import type { OrderData } from "./data";
+import { useState, type FormEvent } from "react";
+import type { OrderData, ToastType } from "./data";
 import {
-  Container,
+  FormContainer,
   Section,
   SectionTitle,
+  StatusTag,
   InfoGrid,
   Label,
-  Value,
-  StatusTag,
-  ModifyButton,
+  StaticText,
+  Input,
+  SubmitButton,
 } from "./styled";
+import {
+  MdReceipt,
+  MdPerson,
+  MdLocalShipping,
+} from "react-icons/md";
+import Toast from "@/components/ui/Toast";
 
 const OrderDetails = ({ order }: { order: OrderData }) => {
+  const [shipping, setShipping] = useState(order.shippinginfo);
+  const [showToast, setShowToast] = useState(false);
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    console.log("submit");
+    setShowToast(true);
+  };
+
   return (
-    <Container>
+    <FormContainer onSubmit={handleSubmit}>
       <Section>
         <SectionTitle>訂單狀態</SectionTitle>
         <StatusTag>{order.orderStatus}</StatusTag>
       </Section>
 
       <Section>
-        <SectionTitle>訂單摘要</SectionTitle>
+        <SectionTitle>
+          <MdReceipt size={24} />
+          訂單摘要
+        </SectionTitle>
         <InfoGrid>
           <Label>訂單編號</Label>
-          <Value>{order.orderCode}</Value>
+          <StaticText>{order.orderCode}</StaticText>
         </InfoGrid>
         <InfoGrid>
           <Label>商品名稱</Label>
-          <Value>{order.details.productName}</Value>
+          <StaticText>{order.details.productName}</StaticText>
         </InfoGrid>
         <InfoGrid>
           <Label>租借期間</Label>
-          <Value>
-            {order.details.rentStamp}
-            {order.details.returnStamp}
-          </Value>
+          <StaticText>
+            {order.details.rentStamp} ~ {order.details.returnStamp}
+          </StaticText>
         </InfoGrid>
         <InfoGrid>
           <Label>租金</Label>
-          <Value>${order.details.rent}</Value>
+          <StaticText>${order.details.rent}</StaticText>
         </InfoGrid>
         <InfoGrid>
           <Label>押金</Label>
-          <Value>${order.details.deposit}</Value>
+          <StaticText>${order.details.deposit}</StaticText>
         </InfoGrid>
         <InfoGrid>
           <Label>運費</Label>
-          <Value>${order.details.fee}</Value>
+          <StaticText>${order.details.fee}</StaticText>
         </InfoGrid>
         <InfoGrid>
           <Label>總金額</Label>
-          <Value>${order.details.finalAmount}</Value>
+          <StaticText>${order.details.finalAmount}</StaticText>
         </InfoGrid>
         <InfoGrid>
           <Label>付款方式</Label>
-          <Value>{order.details.payment}</Value>
+          <StaticText>{order.details.payment}</StaticText>
         </InfoGrid>
       </Section>
 
       <Section>
-        <SectionTitle>下單用戶</SectionTitle>
+        <SectionTitle>
+          <MdPerson size={24} />
+          下單用戶
+        </SectionTitle>
         <InfoGrid>
           <Label>用戶帳號</Label>
-          <Value>
-            {order.member.name}
-            {order.member.email}
-          </Value>
+          <StaticText>{order.member.email}</StaticText>
         </InfoGrid>
         <InfoGrid>
           <Label>line ID</Label>
-          <Value>{order.member.lineId}</Value>
+          <StaticText>{order.member.lineId}</StaticText>
         </InfoGrid>
         <InfoGrid>
           <Label>電話</Label>
-          <Value>{order.member.phone}</Value>
+          <StaticText>{order.member.phone}</StaticText>
         </InfoGrid>
       </Section>
 
       <Section>
-        <SectionTitle>宅配資料</SectionTitle>
+        <SectionTitle>
+          <MdLocalShipping size={24} />
+          宅配資料
+        </SectionTitle>
         <InfoGrid>
-          <Label>姓名</Label>
-          <Value>{order.shippinginfo.name}</Value>
+          <Label htmlFor="name">姓名</Label>
+          <Input
+            id="name"
+            value={shipping.name}
+            onChange={(e) =>
+              setShipping((prev) => ({ ...prev, name: e.target.value }))
+            }
+          />
         </InfoGrid>
         <InfoGrid>
-          <Label>手機</Label>
-          <Value>{order.shippinginfo.phone}</Value>
+          <Label htmlFor="phone">手機</Label>
+          <Input
+            id="phone"
+            value={shipping.phone}
+            onChange={(e) =>
+              setShipping((prev) => ({ ...prev, phone: e.target.value }))
+            }
+          />
         </InfoGrid>
         <InfoGrid>
-          <Label>電子郵件</Label>
-          <Value>{order.shippinginfo.email}</Value>
+          <Label htmlFor="email">電子郵件</Label>
+          <Input
+            id="email"
+            type="email"
+            value={shipping.email}
+            onChange={(e) =>
+              setShipping((prev) => ({ ...prev, email: e.target.value }))
+            }
+          />
         </InfoGrid>
         <InfoGrid>
-          <Label>郵遞區號</Label>
-          <Value>{order.shippinginfo.addressZIP}</Value>
+          <Label htmlFor="zipCode">郵遞區號</Label>
+          <Input
+            id="zipCode"
+            value={shipping.addressZIP}
+            onChange={(e) =>
+              setShipping((prev) => ({ ...prev, zipCode: e.target.value }))
+            }
+          />
         </InfoGrid>
         <InfoGrid>
-          <Label>縣市</Label>
-          <Value>{order.shippinginfo.addressCity}</Value>
+          <Label htmlFor="city">縣市</Label>
+          <Input
+            id="city"
+            value={shipping.addressCity}
+            onChange={(e) =>
+              setShipping((prev) => ({ ...prev, city: e.target.value }))
+            }
+          />
         </InfoGrid>
         <InfoGrid>
-          <Label>鄉鎮市區</Label>
-          <Value>{order.shippinginfo.addressDistrict}</Value>
+          <Label htmlFor="district">鄉鎮市區</Label>
+          <Input
+            id="district"
+            value={shipping.addressDistrict}
+            onChange={(e) =>
+              setShipping((prev) => ({ ...prev, district: e.target.value }))
+            }
+          />
         </InfoGrid>
         <InfoGrid>
-          <Label>詳細地址</Label>
-          <Value>{order.shippinginfo.address}</Value>
+          <Label htmlFor="address">詳細地址</Label>
+          <Input
+            id="address"
+            value={shipping.address}
+            onChange={(e) =>
+              setShipping((prev) => ({ ...prev, address: e.target.value }))
+            }
+          />
         </InfoGrid>
       </Section>
 
-      <ModifyButton>修改</ModifyButton>
-    </Container>
+      <SubmitButton>修改</SubmitButton>
+
+      {showToast && (
+        <Toast
+          type="success"
+          message="成功儲存"
+          onClose={() => setShowToast(false)}
+        />
+      )}
+    </FormContainer>
   );
 };
 

--- a/components/pages/admin/OrderDetails/index.tsx
+++ b/components/pages/admin/OrderDetails/index.tsx
@@ -1,22 +1,47 @@
 import { useState, type FormEvent } from "react";
-import type { OrderData, ToastType } from "./data";
+import { quantitySelects, type OrderData } from "./data";
 import {
   FormContainer,
   Section,
   SectionTitle,
-  StatusTag,
-  InfoGrid,
   Label,
   StaticText,
   Input,
   SubmitButton,
+  Field,
+  GridRows2,
+  TableWrapper,
+  Table,
+  Th,
+  Td,
+  UserInfo,
+  UserAvatar,
+  UserDetails,
+  UserName,
+  UserEmail,
+  CopyButton,
+  Thead,
+  Tr,
+  Tbody,
+  CopyGroup,
+  TextLabel,
+  TextValue,
+  TextGroup,
+  TextEndGroup,
+  Select,
+  SelectArrowIcon,
+  SelectGroup,
 } from "./styled";
 import {
-  MdReceipt,
   MdPerson,
   MdLocalShipping,
+  MdContentCopy,
+  MdKeyboardArrowDown,
 } from "react-icons/md";
 import Toast from "@/components/ui/Toast";
+import { Title } from "@/components/ui/titles";
+import { formatCurrency } from "@/helpers/format/currency";
+import { orderStatusColorMapping, orderStatusValues, shippingStatusColorMapping, shippingValues } from "../OrderList/data";
 
 const OrderDetails = ({ order }: { order: OrderData }) => {
   const [shipping, setShipping] = useState(order.shippinginfo);
@@ -24,164 +49,282 @@ const OrderDetails = ({ order }: { order: OrderData }) => {
 
   const handleSubmit = (e: FormEvent) => {
     e.preventDefault();
-    console.log("submit");
+    console.log("submit", shipping);
     setShowToast(true);
   };
 
   return (
     <FormContainer onSubmit={handleSubmit}>
-      <Section>
-        <SectionTitle>訂單狀態</SectionTitle>
-        <StatusTag>{order.orderStatus}</StatusTag>
-      </Section>
+      <Title>
+        訂單編號：{order.orderCode}
+      </Title>
+        <Section>
+          <SectionTitle>訂單狀態</SectionTitle>
+          <GridRows2>
+            <Field>
+              <Label htmlFor="orderStatus">訂單狀態</Label>
+              <SelectGroup>
+                <Select id="orderStatus" $color={orderStatusColorMapping[order.orderStatus].color || "textMuted"}>
+                  {orderStatusValues.map((orderStatus) => (
+                    <option key={orderStatus} value={orderStatus}>
+                      {orderStatus}
+                    </option>
+                  ))}
+                </Select>
+                <SelectArrowIcon>
+                  <MdKeyboardArrowDown size={20} />
+                </SelectArrowIcon>
+              </SelectGroup>
+            </Field>
+            <Field>
+              <Label htmlFor="shippingStatus">物流狀態</Label>
+              <SelectGroup>
+                <Select id="shippingStatus" $color={shippingStatusColorMapping[order.shippingStatus] || "textMuted"}>
+                  {shippingValues.map((shipping) => (
+                    <option key={shipping} value={shipping}>
+                      {shipping}
+                    </option>
+                  ))}
+                </Select>
+                <SelectArrowIcon>
+                  <MdKeyboardArrowDown size={20} />
+                </SelectArrowIcon>
+              </SelectGroup>
+            </Field>
+          </GridRows2>
+        </Section>
 
-      <Section>
-        <SectionTitle>
-          <MdReceipt size={24} />
-          訂單摘要
-        </SectionTitle>
-        <InfoGrid>
-          <Label>訂單編號</Label>
-          <StaticText>{order.orderCode}</StaticText>
-        </InfoGrid>
-        <InfoGrid>
-          <Label>商品名稱</Label>
-          <StaticText>{order.details.productName}</StaticText>
-        </InfoGrid>
-        <InfoGrid>
-          <Label>租借期間</Label>
-          <StaticText>
-            {order.details.rentStamp} ~ {order.details.returnStamp}
-          </StaticText>
-        </InfoGrid>
-        <InfoGrid>
-          <Label>租金</Label>
-          <StaticText>${order.details.rent}</StaticText>
-        </InfoGrid>
-        <InfoGrid>
-          <Label>押金</Label>
-          <StaticText>${order.details.deposit}</StaticText>
-        </InfoGrid>
-        <InfoGrid>
-          <Label>運費</Label>
-          <StaticText>${order.details.fee}</StaticText>
-        </InfoGrid>
-        <InfoGrid>
-          <Label>總金額</Label>
-          <StaticText>${order.details.finalAmount}</StaticText>
-        </InfoGrid>
-        <InfoGrid>
-          <Label>付款方式</Label>
-          <StaticText>{order.details.payment}</StaticText>
-        </InfoGrid>
-      </Section>
+        <Section>
+          <SectionTitle>
+            {/* <MdReceipt size={24} /> */}
+            訂單檢視
+          </SectionTitle>
+          <TextGroup>
+            <TextLabel>品名</TextLabel>
+            <TextValue>{order.details.productName}</TextValue>
+          </TextGroup>
+          <GridRows2>
+            <Field>
+              <Label htmlFor="rentStamp">租借日</Label>
+              <Input
+                id="rentStamp"
+                value={order.details.rentStamp}
+                onChange={(e) => setShipping((prev) => ({ ...prev, rentStamp: e.target.value }))}
+                placeholder="選擇租借日"
+                type="date"
+              />
+            </Field>
+            <Field>
+              <Label htmlFor="returnStamp">歸還日</Label>
+              <Input
+                id="returnStamp"
+                value={order.details.returnStamp}
+                onChange={(e) => setShipping((prev) => ({ ...prev, returnStamp: e.target.value }))}
+                placeholder="選擇歸還日"
+                type="date"
+              />
+            </Field>
+          </GridRows2>
+          <GridRows2>
+            <Field>
+              <Label htmlFor="shipping">取貨方式</Label>
+              <Input
+                id="shipping"
+                value={order.shipping}
+                onChange={(e) => setShipping((prev) => ({ ...prev, shipping: e.target.value }))}
+                placeholder="請選擇取貨方式"
+              />
+            </Field>
+            <Field>
+              <Label htmlFor="rent">租金</Label>
+              <Input
+                id="rent"
+                value={order.details.rent}
+                onChange={(e) => setShipping((prev) => ({ ...prev, rent: e.target.value }))}
+                placeholder="無租金"
+              />
+            </Field>
+          </GridRows2>
+          <GridRows2>
+            <Field>
+              <Label htmlFor="fee">運費</Label>
+              <Input
+                id="fee"
+                value={order.details.fee}
+                onChange={(e) => setShipping((prev) => ({ ...prev, fee: e.target.value }))}
+                placeholder="無運費"
+              />
+            </Field>
+            <Field>
+              <Label htmlFor="deposit">押金</Label>
+              <Input
+                id="deposit"
+                value={order.details.deposit}
+                onChange={(e) => setShipping((prev) => ({ ...prev, deposit: e.target.value }))}
+                placeholder="無押金"
+              />
+            </Field>
+          </GridRows2>
+          <GridRows2>
+            <Field>
+              <Label htmlFor="payment">付款方式</Label>
+              <Input
+                id="payment"
+                value={order.details.payment}
+                onChange={(e) => setShipping((prev) => ({ ...prev, payment: e.target.value }))}
+                placeholder="無付款方式"
+              />
+            </Field>
+            <Field>
+              <Label htmlFor="quantity">數量</Label>
+              <SelectGroup>
+                <Select id="quantity" $color="textSecondary">
+                  {quantitySelects.map((quantity) => (
+                    <option key={quantity} value={quantity}>
+                      {quantity}
+                    </option>
+                  ))}
+                </Select>
+                <SelectArrowIcon>
+                  <MdKeyboardArrowDown size={20} />
+                </SelectArrowIcon>
+              </SelectGroup>
+            </Field>
+          </GridRows2>
+          <TextEndGroup>
+            <TextLabel>總金額</TextLabel>
+            <TextValue>{formatCurrency(order.details.finalAmount)}</TextValue>
+          </TextEndGroup>
+        </Section>
 
-      <Section>
-        <SectionTitle>
-          <MdPerson size={24} />
-          下單用戶
-        </SectionTitle>
-        <InfoGrid>
-          <Label>用戶帳號</Label>
-          <StaticText>{order.member.email}</StaticText>
-        </InfoGrid>
-        <InfoGrid>
-          <Label>line ID</Label>
-          <StaticText>{order.member.lineId}</StaticText>
-        </InfoGrid>
-        <InfoGrid>
-          <Label>電話</Label>
-          <StaticText>{order.member.phone}</StaticText>
-        </InfoGrid>
-      </Section>
+        <Section>
+          <SectionTitle>
+            {/* <MdPerson size={24} /> */}
+            下單用戶
+          </SectionTitle>
+          <TableWrapper>
+            <Table>
+              <Thead>
+                <Tr>
+                  <Th>用戶帳號</Th>
+                  <Th>line ID</Th>
+                  <Th>電話</Th>
+                </Tr>
+              </Thead>
+              <Tbody>
+                <Tr>
+                  <Td>
+                    <UserInfo>
+                      <UserAvatar>
+                        <MdPerson size={20} />
+                      </UserAvatar>
+                      <UserDetails>
+                        <UserName>{order.member.name}</UserName>
+                        <UserEmail>{order.member.email}</UserEmail>
+                      </UserDetails>
+                    </UserInfo>
+                  </Td>
+                  <Td>
+                    <CopyGroup>
+                      {order.member.lineId && (
+                        <>
+                          {order.member.lineId}
+                          <CopyButton type="button" onClick={() => navigator.clipboard.writeText(order.member.lineId)}>
+                            <MdContentCopy size={16} />
+                          </CopyButton>
+                        </>
+                      )}
+                    </CopyGroup>
+                  </Td>
+                  <Td>{order.member.phone}</Td>
+                </Tr>
+              </Tbody>
+            </Table>
+          </TableWrapper>
+        </Section>
 
-      <Section>
-        <SectionTitle>
-          <MdLocalShipping size={24} />
-          宅配資料
-        </SectionTitle>
-        <InfoGrid>
-          <Label htmlFor="name">姓名</Label>
-          <Input
-            id="name"
-            value={shipping.name}
-            onChange={(e) =>
-              setShipping((prev) => ({ ...prev, name: e.target.value }))
-            }
-          />
-        </InfoGrid>
-        <InfoGrid>
-          <Label htmlFor="phone">手機</Label>
-          <Input
-            id="phone"
-            value={shipping.phone}
-            onChange={(e) =>
-              setShipping((prev) => ({ ...prev, phone: e.target.value }))
-            }
-          />
-        </InfoGrid>
-        <InfoGrid>
-          <Label htmlFor="email">電子郵件</Label>
-          <Input
-            id="email"
-            type="email"
-            value={shipping.email}
-            onChange={(e) =>
-              setShipping((prev) => ({ ...prev, email: e.target.value }))
-            }
-          />
-        </InfoGrid>
-        <InfoGrid>
-          <Label htmlFor="zipCode">郵遞區號</Label>
-          <Input
-            id="zipCode"
-            value={shipping.addressZIP}
-            onChange={(e) =>
-              setShipping((prev) => ({ ...prev, zipCode: e.target.value }))
-            }
-          />
-        </InfoGrid>
-        <InfoGrid>
-          <Label htmlFor="city">縣市</Label>
-          <Input
-            id="city"
-            value={shipping.addressCity}
-            onChange={(e) =>
-              setShipping((prev) => ({ ...prev, city: e.target.value }))
-            }
-          />
-        </InfoGrid>
-        <InfoGrid>
-          <Label htmlFor="district">鄉鎮市區</Label>
-          <Input
-            id="district"
-            value={shipping.addressDistrict}
-            onChange={(e) =>
-              setShipping((prev) => ({ ...prev, district: e.target.value }))
-            }
-          />
-        </InfoGrid>
-        <InfoGrid>
-          <Label htmlFor="address">詳細地址</Label>
-          <Input
-            id="address"
-            value={shipping.address}
-            onChange={(e) =>
-              setShipping((prev) => ({ ...prev, address: e.target.value }))
-            }
-          />
-        </InfoGrid>
-      </Section>
+        <Section>
+          <SectionTitle>
+            <MdLocalShipping size={24} />
+            {/* 宅配資料 */}
+          </SectionTitle>
+          <Field>
+            <Label htmlFor="name">姓名</Label>
+            <Input
+              id="name"
+              value={shipping.name}
+              onChange={(e) => setShipping((prev) => ({ ...prev, name: e.target.value }))}
+              placeholder="請輸入姓名"
+            />
+          </Field>
+          <Field>
+            <Label htmlFor="phone">手機</Label>
+            <Input
+              id="phone"
+              value={shipping.phone}
+              onChange={(e) => setShipping((prev) => ({ ...prev, phone: e.target.value }))}
+              placeholder="請輸入手機號碼"
+            />
+          </Field>
+          <Field>
+            <Label htmlFor="email">電子郵件</Label>
+            <Input
+              id="email"
+              type="email"
+              value={shipping.email}
+              onChange={(e) => setShipping((prev) => ({ ...prev, email: e.target.value }))}
+              placeholder="請輸入電子郵件"
+            />
+          </Field>
+          <Field>
+            <Label htmlFor="zipCode">郵遞區號</Label>
+            <Input
+              id="zipCode"
+              value={shipping.addressZIP}
+              onChange={(e) => setShipping((prev) => ({ ...prev, zipCode: e.target.value }))}
+              placeholder="請輸入郵遞區號"
+            />
+          </Field>
+          <GridRows2>
+            <Field>
+              <Label htmlFor="city">縣市</Label>
+              <Input
+                id="city"
+                value={shipping.addressCity}
+                onChange={(e) => setShipping((prev) => ({ ...prev, addressCity: e.target.value }))}
+                placeholder="請選擇縣市"
+              />
+            </Field>
+            <Field>
+              <Label htmlFor="district">鄉鎮區</Label>
+              <Input
+                id="district"
+                value={shipping.addressDistrict}
+                onChange={(e) => setShipping((prev) => ({ ...prev, district: e.target.value }))}
+                placeholder="請選擇鄉鎮區"
+              />
+            </Field>
+          </GridRows2>
+          <Field>
+            <Label htmlFor="address">詳細地址</Label>
+            <Input
+              id="address"
+              value={shipping.address}
+              onChange={(e) => setShipping((prev) => ({ ...prev, address: e.target.value }))}
+              placeholder="請輸入詳細地址"
+            />
+          </Field>
+        </Section>
 
-      <SubmitButton>修改</SubmitButton>
+        <SubmitButton>修改</SubmitButton>
 
-      {showToast && (
-        <Toast
-          type="success"
-          message="成功儲存"
-          onClose={() => setShowToast(false)}
-        />
-      )}
+        {showToast && (
+          <Toast
+            type="success"
+            message="成功儲存"
+            onClose={() => setShowToast(false)}
+          />
+        )}
     </FormContainer>
   );
 };

--- a/components/pages/admin/OrderDetails/index.tsx
+++ b/components/pages/admin/OrderDetails/index.tsx
@@ -1,0 +1,116 @@
+import type { OrderData } from "./data";
+import {
+  Container,
+  Section,
+  SectionTitle,
+  InfoGrid,
+  Label,
+  Value,
+  StatusTag,
+  ModifyButton,
+} from "./styled";
+
+const OrderDetails = ({ order }: { order: OrderData }) => {
+  return (
+    <Container>
+      <Section>
+        <SectionTitle>訂單狀態</SectionTitle>
+        <StatusTag>{order.orderStatus}</StatusTag>
+      </Section>
+
+      <Section>
+        <SectionTitle>訂單摘要</SectionTitle>
+        <InfoGrid>
+          <Label>訂單編號</Label>
+          <Value>{order.orderCode}</Value>
+        </InfoGrid>
+        <InfoGrid>
+          <Label>商品名稱</Label>
+          <Value>{order.details.productName}</Value>
+        </InfoGrid>
+        <InfoGrid>
+          <Label>租借期間</Label>
+          <Value>
+            {order.details.rentStamp}
+            {order.details.returnStamp}
+          </Value>
+        </InfoGrid>
+        <InfoGrid>
+          <Label>租金</Label>
+          <Value>${order.details.rent}</Value>
+        </InfoGrid>
+        <InfoGrid>
+          <Label>押金</Label>
+          <Value>${order.details.deposit}</Value>
+        </InfoGrid>
+        <InfoGrid>
+          <Label>運費</Label>
+          <Value>${order.details.fee}</Value>
+        </InfoGrid>
+        <InfoGrid>
+          <Label>總金額</Label>
+          <Value>${order.details.finalAmount}</Value>
+        </InfoGrid>
+        <InfoGrid>
+          <Label>付款方式</Label>
+          <Value>{order.details.payment}</Value>
+        </InfoGrid>
+      </Section>
+
+      <Section>
+        <SectionTitle>下單用戶</SectionTitle>
+        <InfoGrid>
+          <Label>用戶帳號</Label>
+          <Value>
+            {order.member.name}
+            {order.member.email}
+          </Value>
+        </InfoGrid>
+        <InfoGrid>
+          <Label>line ID</Label>
+          <Value>{order.member.lineId}</Value>
+        </InfoGrid>
+        <InfoGrid>
+          <Label>電話</Label>
+          <Value>{order.member.phone}</Value>
+        </InfoGrid>
+      </Section>
+
+      <Section>
+        <SectionTitle>宅配資料</SectionTitle>
+        <InfoGrid>
+          <Label>姓名</Label>
+          <Value>{order.shippinginfo.name}</Value>
+        </InfoGrid>
+        <InfoGrid>
+          <Label>手機</Label>
+          <Value>{order.shippinginfo.phone}</Value>
+        </InfoGrid>
+        <InfoGrid>
+          <Label>電子郵件</Label>
+          <Value>{order.shippinginfo.email}</Value>
+        </InfoGrid>
+        <InfoGrid>
+          <Label>郵遞區號</Label>
+          <Value>{order.shippinginfo.addressZIP}</Value>
+        </InfoGrid>
+        <InfoGrid>
+          <Label>縣市</Label>
+          <Value>{order.shippinginfo.addressCity}</Value>
+        </InfoGrid>
+        <InfoGrid>
+          <Label>鄉鎮市區</Label>
+          <Value>{order.shippinginfo.addressDistrict}</Value>
+        </InfoGrid>
+        <InfoGrid>
+          <Label>詳細地址</Label>
+          <Value>{order.shippinginfo.address}</Value>
+        </InfoGrid>
+      </Section>
+
+      <ModifyButton>修改</ModifyButton>
+    </Container>
+  );
+};
+
+export default OrderDetails;

--- a/components/pages/admin/OrderDetails/styled.tsx
+++ b/components/pages/admin/OrderDetails/styled.tsx
@@ -60,17 +60,24 @@ export const Input = styled.input`
   &::placeholder {
     color: ${({ theme }) => theme.colors.border};
   }
+
+  /* 隱藏 Chrome, Safari, Edge, Opera 預設上下箭頭 */
+  &::-webkit-outer-spin-button,
+  &::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
 `;
 
 export const SelectGroup = styled.div`
   position: relative;
 `;
 
-export const Select = styled.select<Color>`
+export const Select = styled.select`
   width: 100%;
   ${AdminInputFieldShadow};
   font-size: 16px;
-  color: ${({ theme, $color }) => theme.colors[$color]};
+  color: ${({ theme }) => theme.colors.textPrimary};
   padding: 6px 32px 6px 12px;
 
   &:focus,
@@ -241,17 +248,24 @@ export const CopyButton = styled.button`
 
 export const SubmitButton = styled.button.attrs({ type: "submit" })`
   width: 100%;
-  padding: 12px;
+  display: flex;
+  justify-content: center;
   background: ${({ theme }) => theme.colors.primary};
   color: ${({ theme }) => theme.colors.white};
   border: none;
   border-radius: 4px;
-  cursor: pointer;
   font-size: 16px;
   font-weight: 500;
   transition: background-color 0.2s;
+  padding: 12px;
 
   &:hover {
     background: ${({ theme }) => theme.colors.primaryHover};
+  }
+
+  &:disabled {
+    opacity: 0.6;
+    background: ${({ theme }) => theme.colors.primary};
+    cursor: not-allowed;
   }
 `;

--- a/components/pages/admin/OrderDetails/styled.tsx
+++ b/components/pages/admin/OrderDetails/styled.tsx
@@ -1,9 +1,12 @@
 import styled from "styled-components";
 import { H4 } from "@/styles/typography";
-import { CardRadius } from "@/styles/borderRadius";
-import { ShadowLow } from "@/styles/effect";
+import { CardRadius, InputRadius } from "@/styles/borderRadius";
+import { ShadowLow, InputFieldTransition } from "@/styles/effect";
 
-export const Container = styled.div`
+export const FormContainer = styled.form`
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
   padding: 24px;
   background: ${({ theme }) => theme.colors.white};
 `;
@@ -11,42 +14,68 @@ export const Container = styled.div`
 export const Section = styled.section`
   ${CardRadius};
   ${ShadowLow};
-  padding: 20px;
+  padding: 24px;
   background: ${({ theme }) => theme.colors.secondaryBg};
-  margin-bottom: 24px;
 `;
 
 export const SectionTitle = styled.h2`
   ${H4};
   color: ${({ theme }) => theme.colors.textPrimary};
-  margin-bottom: 16px;
-`;
-
-export const InfoGrid = styled.div`
-  display: grid;
-  grid-template-columns: 120px 1fr;
-  gap: 12px;
-  margin-bottom: 8px;
-`;
-
-export const Label = styled.span`
-  color: ${({ theme }) => theme.colors.textMuted};
-`;
-
-export const Value = styled.span`
-  color: ${({ theme }) => theme.colors.textPrimary};
+  margin-bottom: 20px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
 `;
 
 export const StatusTag = styled.div`
   display: inline-flex;
   align-items: center;
-  padding: 4px 12px;
-  border-radius: 16px;
+  padding: 6px 16px;
+  border-radius: 20px;
   background: ${({ theme }) => theme.colors.primaryLight};
   color: ${({ theme }) => theme.colors.primary};
+  font-size: 14px;
 `;
 
-export const ModifyButton = styled.button`
+export const InfoGrid = styled.div`
+  display: grid;
+  grid-template-columns: 120px 1fr;
+  gap: 16px;
+  align-items: center;
+  margin-bottom: 16px;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+`;
+
+export const Label = styled.label`
+  color: ${({ theme }) => theme.colors.textSecondary};
+  font-size: 14px;
+`;
+
+export const StaticText = styled.span`
+  color: ${({ theme }) => theme.colors.textPrimary};
+  font-size: 14px;
+`;
+
+export const Input = styled.input`
+  ${InputRadius};
+  ${InputFieldTransition};
+  width: 100%;
+  padding: 8px 12px;
+  border: 1px solid ${({ theme }) => theme.colors.border};
+  background: ${({ theme }) => theme.colors.white};
+  color: ${({ theme }) => theme.colors.textPrimary};
+  font-size: 14px;
+
+  &:focus {
+    outline: none;
+    border-color: ${({ theme }) => theme.colors.primary};
+  }
+`;
+
+export const SubmitButton = styled.button.attrs({ type: "submit" })`
   width: 100%;
   padding: 12px;
   background: ${({ theme }) => theme.colors.primary};
@@ -54,6 +83,9 @@ export const ModifyButton = styled.button`
   border: none;
   border-radius: 4px;
   cursor: pointer;
+  font-size: 16px;
+  font-weight: 500;
+  transition: background-color 0.2s;
 
   &:hover {
     background: ${({ theme }) => theme.colors.primaryHover};

--- a/components/pages/admin/OrderDetails/styled.tsx
+++ b/components/pages/admin/OrderDetails/styled.tsx
@@ -246,7 +246,7 @@ export const CopyButton = styled.button`
   }
 `;
 
-export const SubmitButton = styled.button.attrs({ type: "submit" })`
+export const SubmitButton = styled.button`
   width: 100%;
   display: flex;
   justify-content: center;

--- a/components/pages/admin/OrderDetails/styled.tsx
+++ b/components/pages/admin/OrderDetails/styled.tsx
@@ -1,57 +1,38 @@
 import styled from "styled-components";
-import { H4 } from "@/styles/typography";
-import { CardRadius, InputRadius } from "@/styles/borderRadius";
-import { ShadowLow, InputFieldTransition } from "@/styles/effect";
+import {
+  AdminInputFieldShadow,
+  AdminInputFieldAutofill,
+} from "@/styles/effect";
+import { singleEllipsis } from "@/styles/singleEllipsis";
+import { Color } from "@/types/uiProps";
 
 export const FormContainer = styled.form`
   display: flex;
   flex-direction: column;
-  gap: 24px;
-  padding: 24px;
-  background: ${({ theme }) => theme.colors.white};
-`;
-
-export const Section = styled.section`
-  ${CardRadius};
-  ${ShadowLow};
+  row-gap: 24px;
   padding: 24px;
   background: ${({ theme }) => theme.colors.secondaryBg};
 `;
 
+export const Section = styled.section`
+  padding: 18px 16px;
+  background: ${({ theme }) => theme.colors.white};
+`;
+
 export const SectionTitle = styled.h2`
-  ${H4};
+  font-weight: 700;
+  font-size: 20px;
   color: ${({ theme }) => theme.colors.textPrimary};
-  margin-bottom: 20px;
   display: flex;
   align-items: center;
   gap: 8px;
-`;
-
-export const StatusTag = styled.div`
-  display: inline-flex;
-  align-items: center;
-  padding: 6px 16px;
-  border-radius: 20px;
-  background: ${({ theme }) => theme.colors.primaryLight};
-  color: ${({ theme }) => theme.colors.primary};
-  font-size: 14px;
-`;
-
-export const InfoGrid = styled.div`
-  display: grid;
-  grid-template-columns: 120px 1fr;
-  gap: 16px;
-  align-items: center;
-  margin-bottom: 16px;
-
-  &:last-child {
-    margin-bottom: 0;
-  }
+  margin-bottom: 20px;
 `;
 
 export const Label = styled.label`
-  color: ${({ theme }) => theme.colors.textSecondary};
   font-size: 14px;
+  color: ${({ theme }) => theme.colors.textSecondary};
+  padding-bottom: 8px;
 `;
 
 export const StaticText = styled.span`
@@ -60,18 +41,201 @@ export const StaticText = styled.span`
 `;
 
 export const Input = styled.input`
-  ${InputRadius};
-  ${InputFieldTransition};
   width: 100%;
-  padding: 8px 12px;
-  border: 1px solid ${({ theme }) => theme.colors.border};
-  background: ${({ theme }) => theme.colors.white};
+  background: transparent;
+  ${AdminInputFieldShadow};
   color: ${({ theme }) => theme.colors.textPrimary};
-  font-size: 14px;
+  font-size: 16px;
+  padding: 6px 12px;
 
-  &:focus {
-    outline: none;
-    border-color: ${({ theme }) => theme.colors.primary};
+  &:focus,
+  &:hover {
+    box-shadow: 0px 0px 0px 1.5px ${({ theme }) => theme.colors.primary};
+  }
+
+  &:-webkit-autofill {
+    ${AdminInputFieldAutofill};
+  }
+
+  &::placeholder {
+    color: ${({ theme }) => theme.colors.border};
+  }
+`;
+
+export const SelectGroup = styled.div`
+  position: relative;
+`;
+
+export const Select = styled.select<Color>`
+  width: 100%;
+  ${AdminInputFieldShadow};
+  font-size: 16px;
+  color: ${({ theme, $color }) => theme.colors[$color]};
+  padding: 6px 32px 6px 12px;
+
+  &:focus,
+  &:hover {
+    box-shadow: 0px 0px 0px 1.5px ${({ theme }) => theme.colors.primary};
+  }
+
+  &:-webkit-autofill {
+    ${AdminInputFieldAutofill};
+  }
+`;
+
+export const SelectArrowIcon = styled.div`
+  display: flex;
+  align-items: center;
+  position: absolute;
+  right: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  pointer-events: none;
+  color: ${({ theme }) => theme.colors.textMuted};
+`;
+
+export const TextGroup = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 14px;
+`;
+
+export const TextEndGroup = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 4px;
+`;
+
+export const TextLabel = styled.span`
+  color: ${({ theme }) => theme.colors.textSecondary};
+  font-size: 14px;
+`;
+
+export const TextValue = styled.span`
+  ${singleEllipsis};
+  color: ${({ theme }) => theme.colors.textPrimary};
+  font-size: 16px;
+`;
+
+export const Field = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 16px;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+`;
+
+export const GridRows2 = styled.div`
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+`;
+
+export const TableWrapper = styled.div`
+  width: 100%;
+  overflow-x: auto;
+  background: ${({ theme }) => theme.colors.white};
+`;
+
+export const Table = styled.table`
+  width: 100%;
+  border-collapse: collapse;
+`;
+
+export const Thead = styled.thead`
+  background: ${({ theme }) => theme.colors.secondaryBg};
+`;
+
+export const Tbody = styled.tbody`
+  background: ${({ theme }) => theme.colors.white};
+`;
+
+export const Tr = styled.tr`
+  font-size: 14px;
+`;
+
+export const Th = styled.th`
+  padding: 12px;
+  text-align: left;
+  font-weight: 500;
+  color: ${({ theme }) => theme.colors.textSecondary};
+  border-bottom: 1px solid ${({ theme }) => theme.colors.border};
+
+  &:first-child {
+    padding-left: 24px;
+  }
+
+  &:last-child {
+    padding-right: 24px;
+  }
+`;
+
+export const Td = styled.td`
+  padding: 16px 12px;
+  color: ${({ theme }) => theme.colors.textPrimary};
+  border-bottom: 1px solid ${({ theme }) => theme.colors.border};
+
+  &:first-child {
+    padding-left: 24px;
+  }
+
+  &:last-child {
+    padding-right: 24px;
+  }
+`;
+
+export const UserInfo = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 12px;
+`;
+
+export const UserAvatar = styled.div`
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: ${({ theme }) => theme.colors.secondaryBg};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+export const UserDetails = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+`;
+
+export const UserName = styled.div`
+  font-weight: 500;
+  color: ${({ theme }) => theme.colors.textPrimary};
+`;
+
+export const UserEmail = styled.div`
+  font-size: 12px;
+  color: ${({ theme }) => theme.colors.textSecondary};
+`;
+
+export const CopyGroup = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+`;
+
+export const CopyButton = styled.button`
+  background: none;
+  border: none;
+  padding: 4px;
+  cursor: pointer;
+  color: ${({ theme }) => theme.colors.textSecondary};
+  transition: color 0.2s;
+
+  &:hover {
+    color: ${({ theme }) => theme.colors.primary};
   }
 `;
 

--- a/components/pages/admin/OrderDetails/styled.tsx
+++ b/components/pages/admin/OrderDetails/styled.tsx
@@ -1,0 +1,61 @@
+import styled from "styled-components";
+import { H4 } from "@/styles/typography";
+import { CardRadius } from "@/styles/borderRadius";
+import { ShadowLow } from "@/styles/effect";
+
+export const Container = styled.div`
+  padding: 24px;
+  background: ${({ theme }) => theme.colors.white};
+`;
+
+export const Section = styled.section`
+  ${CardRadius};
+  ${ShadowLow};
+  padding: 20px;
+  background: ${({ theme }) => theme.colors.secondaryBg};
+  margin-bottom: 24px;
+`;
+
+export const SectionTitle = styled.h2`
+  ${H4};
+  color: ${({ theme }) => theme.colors.textPrimary};
+  margin-bottom: 16px;
+`;
+
+export const InfoGrid = styled.div`
+  display: grid;
+  grid-template-columns: 120px 1fr;
+  gap: 12px;
+  margin-bottom: 8px;
+`;
+
+export const Label = styled.span`
+  color: ${({ theme }) => theme.colors.textMuted};
+`;
+
+export const Value = styled.span`
+  color: ${({ theme }) => theme.colors.textPrimary};
+`;
+
+export const StatusTag = styled.div`
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 12px;
+  border-radius: 16px;
+  background: ${({ theme }) => theme.colors.primaryLight};
+  color: ${({ theme }) => theme.colors.primary};
+`;
+
+export const ModifyButton = styled.button`
+  width: 100%;
+  padding: 12px;
+  background: ${({ theme }) => theme.colors.primary};
+  color: ${({ theme }) => theme.colors.white};
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+
+  &:hover {
+    background: ${({ theme }) => theme.colors.primaryHover};
+  }
+`;

--- a/components/pages/admin/OrderList/data.ts
+++ b/components/pages/admin/OrderList/data.ts
@@ -1,3 +1,4 @@
+import { ColorsType } from "@/types/uiProps";
 import type { IconType } from "react-icons";
 import {
   MdPayment,
@@ -42,6 +43,22 @@ export const orderStatuses: OrderStatus[] = [
   { key: "returned", label: "已歸還", count: 6, icon: MdInventory },
   { key: "cancelled", label: "已取消", count: 2, icon: MdCheckCircle },
 ];
+
+export const shippingStatusColorMapping: Record<string, ColorsType> = {
+  "待出貨": "accent",
+  "待取貨": "accent",
+  "運送中": "secondary",
+  "已抵達": "primary",
+  "已取貨": "primary",
+  "已歸還": "textMuted",
+  "已取消": "textMuted",
+};
+
+export const orderStatusColorMapping: Record<string, { color: ColorsType; bgColor: ColorsType }> = {
+  "未付款": { color: "accent", bgColor: "accentLight" },
+  "已付款": { color: "grey300", bgColor: "secondaryBg" },
+  "已結案": { color: "textMuted", bgColor: "secondaryBg" },
+};
 
 export const orderStatusValues: ShippingStatus = ["未付款", "已付款", "已結案"];
 export const shippingValues: ShippingStatus = ["待出貨", "運送中", "已抵達", "待取貨", "已取貨", "已歸還", "已取消"];

--- a/components/pages/admin/OrderList/data.ts
+++ b/components/pages/admin/OrderList/data.ts
@@ -44,7 +44,12 @@ export const orderStatuses: OrderStatus[] = [
   { key: "cancelled", label: "已取消", count: 2, icon: MdCheckCircle },
 ];
 
-export const shippingStatusColorMapping: Record<string, ColorsType> = {
+export const orderStatusValues = ["未付款", "已付款", "已結案"];
+export const shippingValues = ["待出貨", "運送中", "已抵達", "待取貨", "已取貨", "已歸還", "已取消"];
+export type OrderStatusType = typeof orderStatusValues[number];
+export type ShippingStatusType = typeof shippingValues[number];
+
+export const shippingStatusColorMapping: Record<ShippingStatusType, ColorsType> = {
   "待出貨": "accent",
   "待取貨": "accent",
   "運送中": "secondary",
@@ -52,16 +57,13 @@ export const shippingStatusColorMapping: Record<string, ColorsType> = {
   "已取貨": "primary",
   "已歸還": "textMuted",
   "已取消": "textMuted",
-};
+} satisfies Record<ShippingStatusType, ColorsType>;
 
-export const orderStatusColorMapping: Record<string, { color: ColorsType; bgColor: ColorsType }> = {
+export const orderStatusColorMapping: Record<OrderStatusType, { color: ColorsType; bgColor: ColorsType }> = {
   "未付款": { color: "accent", bgColor: "accentLight" },
   "已付款": { color: "grey300", bgColor: "secondaryBg" },
   "已結案": { color: "textMuted", bgColor: "secondaryBg" },
-};
-
-export const orderStatusValues: ShippingStatus = ["未付款", "已付款", "已結案"];
-export const shippingValues: ShippingStatus = ["待出貨", "運送中", "已抵達", "待取貨", "已取貨", "已歸還", "已取消"];
+} satisfies Record<OrderStatusType, { color: ColorsType; bgColor: ColorsType }>;
 
 export const mockOrders: Order[] = [
   {

--- a/components/pages/admin/OrderList/index.tsx
+++ b/components/pages/admin/OrderList/index.tsx
@@ -23,7 +23,12 @@ import {
   Thead,
   Tbody,
 } from "./styled";
-import { orderStatuses, shippingValues } from "./data";
+import {
+  orderStatusColorMapping,
+  orderStatuses,
+  shippingStatusColorMapping,
+  shippingValues,
+} from "./data";
 import Link from "next/link";
 import { ColorsType } from "@/types/uiProps";
 import { CgArrowLongDown, CgArrowLongUp } from "react-icons/cg";
@@ -31,36 +36,19 @@ import { Header } from "@/components/pages/admin/Header";
 import { OrderDataType } from "@/types/getAdminOrders";
 import { formatCurrency } from "@/helpers/format/currency";
 
-const shippingStatusColorMapping = (status: string): ColorsType => {
-  switch (status) {
-    case "待出貨":
-    case "待取貨":
-      return "accent";
-    case "運送中":
-      return "secondary";
-    case "已抵達":
-    case "已取貨":
-      return "primary";
-    case "已歸還":
-    case "已取消":
-    default:
-      return "textMuted";
-  }
-};
-
-const orderStatusColorMapping = (
-  status: string,
-): { color: ColorsType; bgColor: ColorsType } => {
-  switch (status) {
-    case "未付款":
-      return { color: "accent", bgColor: "accentLight" };
-    case "已付款":
-      return { color: "grey300", bgColor: "secondaryBg" };
-    case "已結案":
-    default:
-      return { color: "textMuted", bgColor: "secondaryBg" };
-  }
-};
+// const orderStatusColorMapping = (
+//   status: string,
+// ): { color: ColorsType; bgColor: ColorsType } => {
+//   switch (status) {
+//     case "未付款":
+//       return { color: "accent", bgColor: "accentLight" };
+//     case "已付款":
+//       return { color: "grey300", bgColor: "secondaryBg" };
+//     case "已結案":
+//     default:
+//       return { color: "textMuted", bgColor: "secondaryBg" };
+//   }
+// };
 
 const shippingStatusMapping: { [key: string]: string } = {
   delivery: "宅配",
@@ -177,8 +165,14 @@ const OrderList = ({ data: ordersData = [] }: OrderListProps) => {
               <Td>{formatCurrency(order.finalAmount)}</Td>
               <Td>
                 <StatusButton
-                  $color={orderStatusColorMapping(order.orderStatus).color}
-                  $bgColor={orderStatusColorMapping(order.orderStatus).bgColor}
+                  $color={
+                    orderStatusColorMapping[order.orderStatus]?.color ||
+                    "textMuted"
+                  }
+                  $bgColor={
+                    orderStatusColorMapping[order.orderStatus]?.bgColor ||
+                    "secondaryBg"
+                  }
                 >
                   {orderStatuses.find((s) => s.label === order.orderStatus)
                     ?.label || "已結案"}
@@ -188,7 +182,7 @@ const OrderList = ({ data: ordersData = [] }: OrderListProps) => {
                 <DropdownContainer ref={dropdownRef}>
                   <DropdownTrigger
                     onClick={() => toggleDropdown(order.orderId.toString())}
-                    $color={shippingStatusColorMapping(order.shippingStatus)}
+                    $color={shippingStatusColorMapping[order.shippingStatus]}
                   >
                     {shippingStatuses[order.orderId] || "已取消"}
                     <MdKeyboardArrowDown size={16} />
@@ -200,7 +194,7 @@ const OrderList = ({ data: ordersData = [] }: OrderListProps) => {
                       <DropdownItem
                         key={status}
                         $isSelected={shippingStatuses[order.orderId] === status}
-                        $color={shippingStatusColorMapping(status)}
+                        $color={shippingStatusColorMapping[status] || "textMuted"}
                         onClick={() =>
                           handleShippingStatusChange(
                             order.orderId.toString(),

--- a/components/pages/admin/OrderList/index.tsx
+++ b/components/pages/admin/OrderList/index.tsx
@@ -29,6 +29,7 @@ import { ColorsType } from "@/types/uiProps";
 import { CgArrowLongDown, CgArrowLongUp } from "react-icons/cg";
 import { Header } from "@/components/pages/admin/Header";
 import { OrderDataType } from "@/types/getAdminOrders";
+import { formatCurrency } from "@/helpers/format/currency";
 
 const shippingStatusColorMapping = (status: string): ColorsType => {
   switch (status) {
@@ -61,11 +62,17 @@ const orderStatusColorMapping = (
   }
 };
 
+const shippingStatusMapping: { [key: string]: string } = {
+  delivery: "宅配",
+  store: "店取",
+};
+
 type OrderListProps = {
   data?: OrderDataType[];
 };
 
 const OrderList = ({ data: ordersData = [] }: OrderListProps) => {
+  console.log("ordersData", ordersData);
   const [activeTab, setActiveTab] = useState("全部");
   const [currentPage, setCurrentPage] = useState(1);
   const [shippingStatuses, setShippingStatuses] = useState<{
@@ -129,7 +136,7 @@ const OrderList = ({ data: ordersData = [] }: OrderListProps) => {
                 </SortIcon>
               </Sort>
             </Th>
-            <Th>品項</Th>
+            <Th>名稱</Th>
             <Th>
               <Sort>
                 租借期間
@@ -153,29 +160,24 @@ const OrderList = ({ data: ordersData = [] }: OrderListProps) => {
               $isCompleted={order.orderStatus === "已結案"}
             >
               <Td>
-                <Link href={`/admin/orders/${order.orderId}`}>
+                <Link href={`/admin/order/${order.orderId}`} target="_blank">
                   {order.orderCode}
                 </Link>
               </Td>
-              <Td>
-                {order.memberName}
-                <small>{order.orderCode}</small>
-              </Td>
+              <Td>{order.memberName}</Td>
               <Td>
                 {order.rentDate}
                 <small>{order.returnDate}</small>
               </Td>
               <Td>{order.quantity}</Td>
-              <Td>{order.finalAmount.toLocaleString()}</Td>
+              <Td>{formatCurrency(order.finalAmount)}</Td>
               <Td>
                 <StatusButton
                   $color={orderStatusColorMapping(order.orderStatus).color}
                   $bgColor={orderStatusColorMapping(order.orderStatus).bgColor}
                 >
-                  {
-                    orderStatuses.find((s) => s.label === order.orderStatus)
-                      ?.label
-                  }
+                  {orderStatuses.find((s) => s.label === order.orderStatus)
+                    ?.label || "已結案"}
                 </StatusButton>
               </Td>
               <Td>
@@ -184,7 +186,7 @@ const OrderList = ({ data: ordersData = [] }: OrderListProps) => {
                     onClick={() => toggleDropdown(order.orderId.toString())}
                     $color={shippingStatusColorMapping(order.shippingStatus)}
                   >
-                    {shippingStatuses[order.orderId] || "選擇狀態"}
+                    {shippingStatuses[order.orderId] || "已取消"}
                     <MdKeyboardArrowDown size={16} />
                   </DropdownTrigger>
                   <DropdownContent
@@ -209,7 +211,7 @@ const OrderList = ({ data: ordersData = [] }: OrderListProps) => {
                   </DropdownContent>
                 </DropdownContainer>
               </Td>
-              <Td>{order.shipping}</Td>
+              <Td>{shippingStatusMapping[order.shipping] || "未選擇"}</Td>
             </Tr>
           ))}
         </Tbody>

--- a/components/pages/admin/OrderList/index.tsx
+++ b/components/pages/admin/OrderList/index.tsx
@@ -157,7 +157,11 @@ const OrderList = ({ data: ordersData = [] }: OrderListProps) => {
           {ordersData.map((order) => (
             <Tr
               key={order.orderId}
-              $isCompleted={order.orderStatus === "已結案"}
+              $isCompleted={
+                !order.orderStatus ||
+                order.orderStatus === "已結案" ||
+                order.orderStatus === "已取消"
+              }
             >
               <Td>
                 <Link href={`/admin/order/${order.orderId}`} target="_blank">
@@ -166,8 +170,8 @@ const OrderList = ({ data: ordersData = [] }: OrderListProps) => {
               </Td>
               <Td>{order.memberName}</Td>
               <Td>
-                {order.rentDate}
-                <small>{order.returnDate}</small>
+                {order.rentStamp}
+                <small>{order.returnStamp}</small>
               </Td>
               <Td>{order.quantity}</Td>
               <Td>{formatCurrency(order.finalAmount)}</Td>

--- a/components/pages/admin/SideBar/index.tsx
+++ b/components/pages/admin/SideBar/index.tsx
@@ -80,6 +80,7 @@ const Sidebar: React.FC = () => {
           <NavLink
             href="/admin/user"
             active={(router.asPath === "/admin/user").toString()}
+            $disabled={true}
           >
             <MdPeople size={20} />
             用戶資料
@@ -89,6 +90,7 @@ const Sidebar: React.FC = () => {
           <NavLink
             href="/admin/diagram"
             active={(router.asPath === "/admin/diagram").toString()}
+            $disabled={true}
           >
             <MdBarChart size={20} />
             數據報表

--- a/components/pages/admin/SideBar/index.tsx
+++ b/components/pages/admin/SideBar/index.tsx
@@ -19,9 +19,6 @@ import {
   IconGroup,
   IconWrapper,
   NotificationBadge,
-  SearchGroup,
-  SearchInput,
-  SearchIcon,
   NavList,
   NavItem,
   NavLink,
@@ -59,13 +56,6 @@ const Sidebar: React.FC = () => {
           </IconWrapper>
         </IconGroup>
       </TopSection>
-
-      <SearchGroup>
-        <SearchIcon>
-          <MdSearch size={20} />
-        </SearchIcon>
-        <SearchInput placeholder="找尋..." />
-      </SearchGroup>
 
       <NavList>
         <NavItem>

--- a/components/pages/admin/SideBar/styled.tsx
+++ b/components/pages/admin/SideBar/styled.tsx
@@ -69,7 +69,7 @@ export const NotificationBadge = styled.span`
   background: ${({ theme }) => theme.colors.error};
   color: ${({ theme }) => theme.colors.white};
   font-size: 12px;
-  padding: 2px 6px;
+  padding: 1px 6px;
   border-radius: 10px;
   min-width: 20px;
   text-align: center;

--- a/components/pages/admin/SideBar/styled.tsx
+++ b/components/pages/admin/SideBar/styled.tsx
@@ -44,7 +44,6 @@ export const IconWrapper = styled.div`
   width: 40px;
   height: 40px;
   border-radius: 50%;
-  /* background: ${({ theme }) => theme.colors.primary}; */
   display: flex;
   align-items: center;
   justify-content: center;
@@ -69,40 +68,6 @@ export const NotificationBadge = styled.span`
   border-radius: 10px;
   min-width: 20px;
   text-align: center;
-`;
-
-export const SearchGroup = styled.div`
-  position: relative;
-  margin-bottom: 20px;
-`;
-
-export const SearchIcon = styled.div`
-  position: absolute;
-  left: 12px;
-  top: 50%;
-  transform: translateY(-50%);
-  color: ${({ theme }) => theme.colors.textMuted};
-  font-size: 0;
-`;
-
-export const SearchInput = styled.input`
-  width: 100%;
-  padding: 12px 12px 12px 40px;
-  border: 1px solid ${({ theme }) => theme.colors.border};
-  border-radius: 8px;
-  font-size: 14px;
-  color: ${({ theme }) => theme.colors.textPrimary};
-  background: transparent;
-
-  &::placeholder {
-    color: ${({ theme }) => theme.colors.textMuted};
-  }
-
-  &:focus {
-    outline: none;
-    border-color: ${({ theme }) => theme.colors.primary};
-    background: ${({ theme }) => theme.colors.white};
-  }
 `;
 
 export const NavList = styled.nav`

--- a/components/pages/admin/SideBar/styled.tsx
+++ b/components/pages/admin/SideBar/styled.tsx
@@ -1,6 +1,11 @@
 import styled from "styled-components";
 import Link from "next/link";
 
+type NavLinkProps = {
+  active?: string;
+  $disabled?: boolean;
+};
+
 export const SidebarContainer = styled.aside`
   width: 280px;
   height: 100vh;
@@ -80,7 +85,7 @@ export const NavItem = styled.div`
   width: 100%;
 `;
 
-export const NavLink = styled(Link)<{ active?: string }>`
+export const NavLink = styled(Link)<NavLinkProps>`
   display: flex;
   align-items: center;
   gap: 12px;
@@ -101,4 +106,11 @@ export const NavLink = styled(Link)<{ active?: string }>`
       color: ${theme.colors.primary};
     `}
   }
+
+  ${({ $disabled }) =>
+    $disabled &&
+    `
+      opacity: 0.5;
+      pointer-events: none;
+  `}
 `;

--- a/components/pages/admin/Suggest/index.tsx
+++ b/components/pages/admin/Suggest/index.tsx
@@ -397,7 +397,12 @@ const SuggestTemplate: React.FC<SuggestType> = ({
         {products.map((product) => (
           <Card key={product.suggestProductId}>
             <ImageWrapper>
-              <Image src={product.imgSrc} alt={product.imgAlt} />
+              <Image
+                src={product.imgSrc}
+                alt={product.imgAlt}
+                width={150}
+                height={150}
+              />
               <PriceBadge>{formatCurrency(product.rent)}/ 月</PriceBadge>
             </ImageWrapper>
             <Info>

--- a/components/pages/admin/Suggest/styled.tsx
+++ b/components/pages/admin/Suggest/styled.tsx
@@ -165,7 +165,7 @@ export const ImageWrapper = styled.div`
 
 export const Image = styled.img`
   width: 100%;
-  max-width: 200px;
+  max-width: 150px;
   height: auto;
 `;
 

--- a/components/pages/cart/Checkout/data.ts
+++ b/components/pages/cart/Checkout/data.ts
@@ -5,7 +5,7 @@ import {
   FormValuesProps,
 } from "@/utils/react-hook-form/InputField/data";
 
-export type PaymentMethodValue = "CreditCard" | "Remit" | "LinePay" | "";
+export type PaymentMethodValue = "creditCard" | "transfer" | "LinePay" | "";
 export type PickupMethodValue = "store" | "delivery" | "";
 
 export const defaultFormValues: FormValuesProps["checkout"] = {
@@ -108,12 +108,12 @@ type PaymentMethod = {
 export const paymentMethods: PaymentMethod[] = [
   {
     id: "creditCard",
-    value: "CreditCard",
+    value: "creditCard",
     icon: "信用卡/簽帳金融卡",
   },
   {
-    id: "remit",
-    value: "Remit",
+    id: "transfer",
+    value: "transfer",
     icon: "銀行匯款或轉帳",
   },
   {

--- a/components/pages/cart/Checkout/index.tsx
+++ b/components/pages/cart/Checkout/index.tsx
@@ -186,13 +186,17 @@ const Checkout = () => {
       return;
     }
 
-    if (data.payment === "Remit") {
+    const isTransferOrCreditCard =
+      data.payment === "transfer" || data.payment === "creditCard";
+
+    if (isTransferOrCreditCard) {
       dispatch(clearActiveCartId());
       alert("訂單已送出，請等待審核");
       router.push("/user/order");
       setIsOrderSubmitting(false);
       return;
     }
+
     const redirectPath = result.data.linePay.PaymentUrl.web;
 
     dispatch(

--- a/components/ui/LoaderSpinner.tsx
+++ b/components/ui/LoaderSpinner.tsx
@@ -1,13 +1,15 @@
 import { RoundedFull } from "@/styles/borderRadius";
+import { ColorsType } from "@/types/uiProps";
 import styled from "styled-components";
 
-export const LoaderSpinner = styled.div`
+export const LoaderSpinner = styled.div<{ $color?: ColorsType }>`
   height: 22.5px;
   width: 22.5px;
-  border: 1px solid ${({ theme }) => theme.colors.textPrimary};
+  border: 1px solid
+    ${({ theme, $color }) =>
+      $color ? theme.colors[$color] : theme.colors.textPrimary};
   ${RoundedFull};
   border-top: none;
   border-right: none;
-  /* margin: 0 auto; */
   animation: spin 1s ease-in-out infinite;
 `;

--- a/components/ui/Toast/data.ts
+++ b/components/ui/Toast/data.ts
@@ -1,0 +1,8 @@
+export type ToastProps = {
+  type: "success" | "error";
+  message: string;
+  duration?: number;
+  $top?: string;
+  $right?: string;
+  onClose: () => void;
+};

--- a/components/ui/Toast/index.tsx
+++ b/components/ui/Toast/index.tsx
@@ -1,0 +1,86 @@
+import { useEffect, useState } from "react";
+import { MdCheckCircle } from "react-icons/md";
+import { ToastContainer } from "./styled";
+import type { ToastProps } from "./data";
+
+/**
+ * Toast 通知元件
+ *
+ * 使用方式：
+ * 1. 在父元件中設置 state 來控制 Toast 的顯示狀態
+ * ```typescript
+ * const [showToast, setShowToast] = useState(false);
+ * ```
+ *
+ * 2. 在需要顯示 Toast 的時候，state(showToast) 設置 true
+ * ```typescript
+ * const handleClick = () => {
+ *   setShowToast(true);
+ * };
+ * ```
+ *
+ * 3. 在 JSX 中使用條件渲染來顯示 Toast
+ * ```typescript
+ * {showToast && (
+ *   <Toast
+ *     type="success"  // 'success' | 'error'
+ *     message="成功儲存"  // 顯示的訊息
+ *     onClose={() => setShowToast(false)}  // Toast 消失時的回調
+ *     duration={3000}  // 可選，預設 3000ms
+ *     $top="24px"     // 可選，預設 24px
+ *     $right="24px"   // 可選，預設 24px
+ *   />
+ * )}
+ * ```
+ *
+ * @param props.type - Toast 類型：'success' | 'error'
+ * @param props.message - 顯示的訊息內容
+ * @param props.onClose - Toast 消失時的回調函數
+ * @param props.duration - 顯示時間（毫秒），預設 3000ms
+ * @param props.$top - 距離頂部的位置，預設 24px
+ * @param props.$right - 距離右側的位置，預設 24px
+ */
+const Toast = ({
+  type,
+  message,
+  duration = 3000,
+  onClose,
+  $top = "24px",
+  $right = "24px",
+}: ToastProps) => {
+  const [isLeaving, setIsLeaving] = useState(false);
+  const animationDuration = 300;
+  const isFunction = typeof onClose === "function";
+
+  useEffect(() => {
+    // 設置 Toast 消失的計時器
+    const hideTimer = setTimeout(() => {
+      setIsLeaving(true);
+    }, duration);
+
+    // 設置移除 Toast 的計時器（包含動畫時間）
+    const removeTimer = setTimeout(() => {
+      isFunction && onClose();
+    }, duration + animationDuration);
+
+    // 計時器清空，避免記憶體洩漏
+    return () => {
+      clearTimeout(hideTimer);
+      clearTimeout(removeTimer);
+    };
+  }, [duration, onClose]);
+
+  return (
+    <ToastContainer
+      type={type}
+      isLeaving={isLeaving}
+      $top={$top}
+      $right={$right}
+    >
+      <MdCheckCircle size={20} />
+      {message}
+    </ToastContainer>
+  );
+};
+
+export default Toast;

--- a/components/ui/Toast/index.tsx
+++ b/components/ui/Toast/index.tsx
@@ -41,8 +41,8 @@ import type { ToastProps } from "./data";
  * @param props.$right - 距離右側的位置，預設 24px
  */
 const Toast = ({
-  type,
-  message,
+  type = "success",
+  message = "成功",
   duration = 3000,
   onClose,
   $top = "24px",

--- a/components/ui/Toast/index.tsx
+++ b/components/ui/Toast/index.tsx
@@ -72,8 +72,8 @@ const Toast = ({
 
   return (
     <ToastContainer
-      type={type}
-      isLeaving={isLeaving}
+      $type={type}
+      $isLeaving={isLeaving}
       $top={$top}
       $right={$right}
     >

--- a/components/ui/Toast/styled.tsx
+++ b/components/ui/Toast/styled.tsx
@@ -30,8 +30,8 @@ export const ToastContainer = styled.div<ToastType>`
   top: ${({ $top }) => $top};
   right: ${({ $right }) => $right};
   padding: 12px 20px;
-  background: ${({ theme, type }) =>
-    type === "success" ? theme.colors.success : theme.colors.error};
+  background: ${({ theme, $type }) =>
+    $type === "success" ? theme.colors.success : theme.colors.error};
   color: ${({ theme }) => theme.colors.white};
   ${InputRadius};
   ${ShadowLow};
@@ -40,8 +40,8 @@ export const ToastContainer = styled.div<ToastType>`
   gap: 8px;
   z-index: 1;
 
-  ${({ isLeaving }) =>
-    isLeaving
+  ${({ $isLeaving }) =>
+    $isLeaving
       ? css`
           animation: ${slideOutRight} 0.3s ease-in-out forwards;
         `

--- a/components/ui/Toast/styled.tsx
+++ b/components/ui/Toast/styled.tsx
@@ -1,0 +1,51 @@
+import styled, { css, keyframes } from "styled-components";
+import { InputRadius } from "@/styles/borderRadius";
+import { ShadowLow } from "@/styles/effect";
+import { Toast as ToastType } from "@/types/uiProps";
+
+const slideInRight = keyframes`
+  from {
+    transform: translateX(100%);
+    opacity: 0;
+  }
+  to {
+    transform: translateX(0);
+    opacity: 1;
+  }
+`;
+
+const slideOutRight = keyframes`
+  from {
+    transform: translateX(0);
+    opacity: 1;
+  }
+  to {
+    transform: translateX(100%);
+    opacity: 0;
+  }
+`;
+
+export const ToastContainer = styled.div<ToastType>`
+  position: fixed;
+  top: ${({ $top }) => $top};
+  right: ${({ $right }) => $right};
+  padding: 12px 20px;
+  background: ${({ theme, type }) =>
+    type === "success" ? theme.colors.success : theme.colors.error};
+  color: ${({ theme }) => theme.colors.white};
+  ${InputRadius};
+  ${ShadowLow};
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  z-index: 1;
+
+  ${({ isLeaving }) =>
+    isLeaving
+      ? css`
+          animation: ${slideOutRight} 0.3s ease-in-out forwards;
+        `
+      : css`
+          animation: ${slideInRight} 0.3s ease-in-out;
+        `};
+`;

--- a/constants/apiPath.ts
+++ b/constants/apiPath.ts
@@ -35,6 +35,8 @@ export const put_admin_suggest = `${baseUrl}${basePath}/admin/suggest`;
 export const put_admin_suggest_product = `${baseUrl}${basePath}/admin/suggest/product`;
 export const get_admin_suggest = `${baseUrl}${basePath}/admin/suggest`;
 export const get_admin_orders = `${baseUrl}${basePath}/admin/orders`;
+export const get_admin_order = `${baseUrl}/api/admin/order/:id`;
+export const put_admin_order = `${baseUrl}/api/admin/order/:id`;
 
 export const post_linepay_confirm = `${baseUrl}${basePath}/linepay/confirm`;
 export const get_linepay_callback = `${baseUrl}/api/account/linecallback`;

--- a/constants/routes.ts
+++ b/constants/routes.ts
@@ -10,7 +10,7 @@ export const routes = {
     inquiry: '/user/inquiry'
   },
   admin: {
-    order: '/admin/order',
+    order: '/admin/orders',
     dashboard: '/admin/dashboard',
     users: '/admin/users'
   }

--- a/next.config.ts
+++ b/next.config.ts
@@ -70,6 +70,12 @@ const nextConfig = {
           }
         ]
       },
+      // 驗證 admin/order/[id] 路徑，正規表達式過濾 id 為數字
+      {
+        source: "/admin/order/:id((?![0-9]+$).*)",
+        destination: "/404",
+        permanent: false
+      },
       // 已登入用戶訪問登入頁面
       {
         source: "/auth/signin",

--- a/next.config.ts
+++ b/next.config.ts
@@ -22,7 +22,7 @@ const nextConfig = {
       },
       {
         source: "/admin",
-        destination: "/admin/order",
+        destination: "/admin/orders",
         permanent: true,
       },
       // 未登入用戶訪問需要驗證的頁面
@@ -84,7 +84,7 @@ const nextConfig = {
             value: "admin"
           }
         ],
-        destination: "/admin/order",
+        destination: "/admin/orders",
         permanent: false,
       },
       {

--- a/pages/admin/order/[id].tsx
+++ b/pages/admin/order/[id].tsx
@@ -1,0 +1,33 @@
+import { hasError } from "@/helpers/api/status";
+import { OrderDataType } from "@/types/getAdminOrders";
+import getOrder from "@/utils/api/admin/getOrder";
+import { GetServerSideProps } from "next";
+
+export const getServerSideProps: GetServerSideProps = async ({
+  params,
+  req,
+}) => {
+  const token = req.cookies.token || "";
+  const orderId = (params?.id as string) || "";
+  console.log("getServerSideProps params", params, orderId);
+
+  const result = await getOrder(token, orderId);
+
+  if (hasError(result)) {
+    console.error("嚴重錯誤:", result.error);
+    throw result.error;
+  }
+
+  return {
+    props: {
+      order: result.data || {},
+    },
+  };
+};
+
+const Order = ({ order }: { order: OrderDataType }) => {
+  console.log("order", order);
+  return <div>{order.orderId}</div>;
+};
+
+export default Order;

--- a/pages/admin/order/[id].tsx
+++ b/pages/admin/order/[id].tsx
@@ -1,7 +1,10 @@
-import { hasError } from "@/helpers/api/status";
-import { OrderDataType } from "@/types/getAdminOrders";
+import AdminLayout from "@/components/pages/admin/Layout";
+import OrderDetails from "@/components/pages/admin/OrderDetails";
+import { OrderData } from "@/components/pages/admin/OrderDetails/data";
+import { hasError, isEmptyData } from "@/helpers/api/status";
 import getOrder from "@/utils/api/admin/getOrder";
 import { GetServerSideProps } from "next";
+import Head from "next/head";
 
 export const getServerSideProps: GetServerSideProps = async ({
   params,
@@ -13,9 +16,17 @@ export const getServerSideProps: GetServerSideProps = async ({
 
   const result = await getOrder(token, orderId);
 
+  console.log("getServerSideProps result", result);
+
   if (hasError(result)) {
     console.error("嚴重錯誤:", result.error);
     throw result.error;
+  }
+
+  if (isEmptyData(result)) {
+    return {
+      notFound: true,
+    };
   }
 
   return {
@@ -25,9 +36,18 @@ export const getServerSideProps: GetServerSideProps = async ({
   };
 };
 
-const Order = ({ order }: { order: OrderDataType }) => {
-  console.log("order", order);
-  return <div>{order.orderId}</div>;
+const Order = ({ order }: { order: OrderData }) => {
+  return (
+    <>
+      <Head>
+        <title>訂單詳情</title>
+        <meta name="description" content="訂單詳情" />
+      </Head>
+      <AdminLayout>
+        <OrderDetails order={order} />
+      </AdminLayout>
+    </>
+  );
 };
 
 export default Order;

--- a/pages/admin/order/[id].tsx
+++ b/pages/admin/order/[id].tsx
@@ -12,11 +12,8 @@ export const getServerSideProps: GetServerSideProps = async ({
 }) => {
   const token = req.cookies.token || "";
   const orderId = (params?.id as string) || "";
-  console.log("getServerSideProps params", params, orderId);
 
   const result = await getOrder(token, orderId);
-
-  console.log("getServerSideProps result", result);
 
   if (hasError(result)) {
     console.error("嚴重錯誤:", result.error);

--- a/pages/api/admin/putOrder.tsx
+++ b/pages/api/admin/putOrder.tsx
@@ -1,0 +1,16 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import putOrder from "@/utils/api/admin/putOrder";
+import { Result } from "@/types/putAdminOrder";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<Result>,
+) {
+  const result = await putOrder(
+    req.cookies.token || "",
+    req.body,
+    req.query.id as string,
+  );
+
+  return res.json(result);
+}

--- a/styles/effect.tsx
+++ b/styles/effect.tsx
@@ -26,9 +26,18 @@ export const InputFieldAutofill = css`
   box-shadow: 0 0 0 1000px ${({ theme }) => theme.colors.secondaryBg} inset;
 `;
 
+export const AdminInputFieldAutofill = css`
+  box-shadow: 0px 1px 0px 0px ${({ theme }) => theme.colors.border},
+    0 0 0 1000px ${({ theme }) => theme.colors.white} inset;
+`;
+
 export const InputFieldShadow = css`
   box-shadow: 0 0 0 1px ${({ theme }) => theme.colors.primary},
     0 0 0 1000px ${({ theme }) => theme.colors.secondaryBg} inset;
+`;
+
+export const AdminInputFieldShadow = css`
+  box-shadow: 0px 1px 0px 0px ${({ theme }) => theme.colors.border};
 `;
 
 export const FooterAutofill = css`

--- a/styles/singleEllipsis.tsx
+++ b/styles/singleEllipsis.tsx
@@ -1,0 +1,9 @@
+import { css } from "styled-components";
+
+export const singleEllipsis = css`
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;

--- a/types/getAdminOrder.ts
+++ b/types/getAdminOrder.ts
@@ -1,0 +1,62 @@
+import { Error } from "@/types/apiRoutes";
+
+export const ResultGetAdminOrder = {
+  statusCode: 0,
+  status: true,
+  message: "",
+  data: {
+    "orderStatus": "未付款",
+    "shippingStatus": "待出貨",
+    "orderCode": "202501180002",
+    "createdDate": "2025-01-18T14:42:12.77",
+    "createdStamp": "2025-01-18",
+    "note": "",
+    "shipping": "宅配",
+    "shippinginfo": {
+        "name": "鄭柏易",
+        "phone": "0958134697",
+        "email": "123@gmail.com",
+        "address": "高雄市12345號",
+        "addressZIP": "812",
+        "addressCity": "高雄市",
+        "addressDistrict": null,
+        "AddressDetail": "12345號"
+    },
+    "details": {
+        "quantity": 1,
+        "productName": "【樂輕行】輕便折疊輪椅",
+        "productDes": "輕巧設計適合日常出行或短途旅行，具防滑腳踏板與可折疊功能，方便收納與攜帶，承重量可達100公斤，是老年人與行動不便人士的理想選擇。\r\n",
+        "productImgSrc": "http://52.172.145.130:8080/picture/wheelChair/wheelChair-1.webp",
+        "productImgAlt": "【樂輕行】輕便折疊輪椅",
+        "rent": 5000.00,
+        "deposit": 500.00,
+        "fee": 200.00,
+        "finalAmount": 5700.00,
+        "period": 30,
+        "rentDate": "2025-01-16T15:26:09.753",
+        "rentStamp": "2025-01-16",
+        "returnDate": "2025-01-16T15:26:09.753",
+        "returnStamp": "2025-01-16",
+        "payment": "LinePay"
+    },
+    "member": {
+        "memberId": 57,
+        "name": "鄭柏易帥哥",
+        "email": "123@yahoo.com",
+        "lineId": "",
+      phone: "0958134697",
+    },
+  },
+};
+
+export type ResultGetAdminOrderType = typeof ResultGetAdminOrder;
+
+export type OrderDataType = ResultGetAdminOrderType["data"];
+
+export type Result = {
+  statusCode: number;
+  status: boolean;
+  message: string;
+  data: OrderDataType | undefined;
+  error: Error | null;
+};

--- a/types/putAdminOrder.ts
+++ b/types/putAdminOrder.ts
@@ -1,0 +1,17 @@
+import { Error } from "@/types/apiRoutes";
+
+export const ResultPutAdminOrder = {
+  "statusCode": 200,
+  "status": true,
+  "message": "成功修改指定會員訂單細節"
+};
+
+export type ResultPutAdminOrderType = typeof ResultPutAdminOrder;
+
+export type Result = {
+  statusCode: number;
+  status: boolean;
+  message: string;
+  data: undefined;
+  error: Error | null;
+};

--- a/types/uiProps.ts
+++ b/types/uiProps.ts
@@ -64,8 +64,8 @@ export type Padding = {
 };
 
 export type Toast = {
-  type: "success" | "error";
-  isLeaving: boolean;
+  $type: "success" | "error";
+  $isLeaving: boolean;
   $top: string;
   $right: string;
 };

--- a/types/uiProps.ts
+++ b/types/uiProps.ts
@@ -33,11 +33,11 @@ export type Shadow = {
 
 export type Color = {
   $color: ColorsType;
-}
+};
 
 export type BgColor = {
   $bgColor: ColorsType;
-}
+};
 
 export type Gap = {
   $gap: number;
@@ -45,20 +45,27 @@ export type Gap = {
 
 export type Size = {
   $size: number;
-}
+};
 
 export type FontSize = {
   $fontSize: number;
-}
+};
 
 export type BorderRadius = {
   $borderRadius: number;
-}
+};
 
 export type Margin = {
   $margin: string;
-}
+};
 
 export type Padding = {
   $padding: string;
-}
+};
+
+export type Toast = {
+  type: "success" | "error";
+  isLeaving: boolean;
+  $top: string;
+  $right: string;
+};

--- a/utils/api/admin/getOrder.tsx
+++ b/utils/api/admin/getOrder.tsx
@@ -1,0 +1,59 @@
+import { Error } from "@/types/apiRoutes";
+import { catchError } from "@/utils/handleErrors";
+import { NODE_ENV } from "@/constants/environment";
+import { validateResponseType } from "@/utils/typeGuards";
+import { get_admin_order } from "@/constants/apiPath";
+import { ResultGetAdminOrder, Result } from "@/types/getAdminOrder";
+
+export const getOrder = async (
+  token: string,
+  orderId: string,
+): Promise<Result> => {
+  const parsedUrl = new URL(get_admin_order.replace(":id", orderId));
+  const options = {
+    method: "GET",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    },
+  };
+
+  const [res, error] = await catchError(fetch(parsedUrl, options));
+
+  if (error) {
+    console.log("error", error);
+
+    const unexpectedError: Error = {
+      code: 500,
+      message: `發生未知錯誤: ${error.message}`,
+    };
+
+    return {
+      statusCode: 500,
+      status: false,
+      message: unexpectedError.message,
+      data: undefined,
+      error: unexpectedError,
+    };
+  }
+
+  const json = await res.json();
+
+  if (NODE_ENV === "development") {
+    const validation = validateResponseType(json, ResultGetAdminOrder);
+
+    !validation.isValid &&
+      console.error("API Response validation failed:", validation.errors);
+  }
+
+  return {
+    statusCode: json.statusCode,
+    status: json.status,
+    message: json.message,
+    data: json.data,
+    error: null,
+  };
+};
+
+export default getOrder;

--- a/utils/api/admin/getOrder.tsx
+++ b/utils/api/admin/getOrder.tsx
@@ -21,6 +21,8 @@ export const getOrder = async (
 
   const [res, error] = await catchError(fetch(parsedUrl, options));
 
+  console.log("getOrder res", res);
+
   if (error) {
     console.log("error", error);
 

--- a/utils/api/admin/getOrder.tsx
+++ b/utils/api/admin/getOrder.tsx
@@ -21,8 +21,6 @@ export const getOrder = async (
 
   const [res, error] = await catchError(fetch(parsedUrl, options));
 
-  console.log("getOrder res", res);
-
   if (error) {
     console.log("error", error);
 

--- a/utils/api/admin/getOrders.tsx
+++ b/utils/api/admin/getOrders.tsx
@@ -18,8 +18,6 @@ export const getOrders = async (token: string): Promise<Result> => {
 
   const [res, error] = await catchError(fetch(parsedUrl, options));
 
-  console.log("res", res, error);
-
   if (error) {
     console.log("error", error);
 
@@ -38,8 +36,6 @@ export const getOrders = async (token: string): Promise<Result> => {
   }
 
   const json = await res.json();
-
-  console.log("json", json);
 
   if (NODE_ENV === "development") {
     const validation = validateResponseType(json, ResultGetAdminOrders);

--- a/utils/api/admin/putOrder.tsx
+++ b/utils/api/admin/putOrder.tsx
@@ -4,9 +4,11 @@ import { NODE_ENV } from "@/constants/environment";
 import { validateResponseType } from "@/utils/typeGuards";
 import { put_admin_order } from "@/constants/apiPath";
 import { ResultPutAdminOrder, Result } from "@/types/putAdminOrder";
+import { OrderData } from "@/components/pages/admin/OrderDetails/data";
 
 export const putOrder = async (
   token: string,
+  order: OrderData,
   orderId: string,
 ): Promise<Result> => {
   const parsedUrl = new URL(put_admin_order.replace(":id", orderId));
@@ -17,6 +19,7 @@ export const putOrder = async (
       Accept: "application/json",
       "Content-Type": "application/json",
     },
+    body: JSON.stringify(order),
   };
 
   const [res, error] = await catchError(fetch(parsedUrl, options));
@@ -51,7 +54,7 @@ export const putOrder = async (
     statusCode: json.statusCode,
     status: json.status,
     message: json.message,
-    data: json.data,
+    data: undefined,
     error: null,
   };
 };

--- a/utils/api/admin/putOrder.tsx
+++ b/utils/api/admin/putOrder.tsx
@@ -1,0 +1,59 @@
+import { Error } from "@/types/apiRoutes";
+import { catchError } from "@/utils/handleErrors";
+import { NODE_ENV } from "@/constants/environment";
+import { validateResponseType } from "@/utils/typeGuards";
+import { put_admin_order } from "@/constants/apiPath";
+import { ResultPutAdminOrder, Result } from "@/types/putAdminOrder";
+
+export const putOrder = async (
+  token: string,
+  orderId: string,
+): Promise<Result> => {
+  const parsedUrl = new URL(put_admin_order.replace(":id", orderId));
+  const options = {
+    method: "PUT",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    },
+  };
+
+  const [res, error] = await catchError(fetch(parsedUrl, options));
+
+  if (error) {
+    console.log("error", error);
+
+    const unexpectedError: Error = {
+      code: 500,
+      message: `發生未知錯誤: ${error.message}`,
+    };
+
+    return {
+      statusCode: 500,
+      status: false,
+      message: unexpectedError.message,
+      data: undefined,
+      error: unexpectedError,
+    };
+  }
+
+  const json = await res.json();
+
+  if (NODE_ENV === "development") {
+    const validation = validateResponseType(json, ResultPutAdminOrder);
+
+    !validation.isValid &&
+      console.error("API Response validation failed:", validation.errors);
+  }
+
+  return {
+    statusCode: json.statusCode,
+    status: json.status,
+    message: json.message,
+    data: json.data,
+    error: null,
+  };
+};
+
+export default putOrder;

--- a/utils/react-hook-form/InputField/data.ts
+++ b/utils/react-hook-form/InputField/data.ts
@@ -12,7 +12,7 @@ export type FormValuesProps = {
   },
   checkout: {
     method: "store" | "delivery" | "";
-    payment: "CreditCard" | "Remit" | "LinePay" | "";
+    payment: "creditCard" | "transfer" | "LinePay" | "";
     name: string;
     phone: string;
     email: string;


### PR DESCRIPTION
 實作後台訂單管理功能與訂單詳情頁面

## 主要功能實作

1. API Routes
- getAdminOrder
- putAdminOrder
- putOrder

2. API Function
- getAdminOrder
- putAdminOrder

3. Toast 元件重構：將 Toast 元件從 OrderDetails 抽離為獨立元件
4. singleEllipsis 實作通用的單行文字省略樣式

## 相關檔案
- components/ui/Toast([index](https://github.com/kentrpg/assist-hub/pull/51/files#diff-fe8df783baa66bba7df99fd788f91440980bac3c337a0668fcb604b67ce1e936)、[styled](https://github.com/kentrpg/assist-hub/pull/51/files#diff-2059f7d8161c3289ea3afdf7ec398caee11154e07a4294c5bcdb5c66c7af8241))
- [styles/singleEllipsis.tsx](https://github.com/kentrpg/assist-hub/pull/51/files#diff-046d521eba81ca7d4d3b69af5a17bf9854fea9196e985029723ffc28d5f5220c)

## 測試功能

- [ ] Toast 元件功能
  - 顯示與隱藏邏輯
  - 動畫效果
  - 自動關閉機制
- [ ] 單行文字省略功能
- [ ] 訂單細節頁
  - 修改訂單訊息
- [ ] 建議單修改
  - 修改推薦原因
  - 修改補充說明
  - 添加輔具商品