### PR TITLE
feat(document): Add site-specific Head and icon

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -10,7 +10,7 @@ import { ServerStyleSheet } from "styled-components";
 
 export default class MyDocument extends Document {
   static async getInitialProps(
-    ctx: DocumentContext
+    ctx: DocumentContext,
   ): Promise<DocumentInitialProps> {
     const sheet = new ServerStyleSheet();
     const originalRenderPage = ctx.renderPage;
@@ -41,7 +41,11 @@ export default class MyDocument extends Document {
     return (
       <Html lang="zh-Hant">
         {/* 在這裡添加全域的 meta 標籤、字體或其他標籤 */}
-        <Head></Head>
+        <Head>
+          <title>RENT4U 輔具租賃網</title>
+          <meta name="description" content="為您打造最適合的輔具商品" />
+          <link rel="icon" href="/images/LOGO.webp" />
+        </Head>
         <body>
           <Main />
           <NextScript />


### PR DESCRIPTION
- 在 `_document.tsx` 中加入網站專屬的 `<Head>` 設定
- 新增網站 favicon 及相關 meta 資訊，優化網站識別性
- 確保所有頁面共用一致的 Head 結構，提高 SEO 及品牌辨識度