### PR TITLE
fix(footer): fix wave background display issues in responsive scaling

### DIFF
--- a/components/layout/Footer/styled.tsx
+++ b/components/layout/Footer/styled.tsx
@@ -20,12 +20,19 @@ export const Wrapper = styled.footer`
     position: absolute;
     left: 0;
     right: 0;
-    top: -120px;
+    top: -115px;
     height: 168px;
-    background-image: url("/images/wave768.webp");
+    background-image: url("/images/wave375.webp");
     background-repeat: repeat-x;
     background-position: top;
+    background-size: 100% 100%;
+    @media ${Mobile} {
+      top: -110px;
+      background-image: url("/images/wave768.webp");
+      background-size: cover;
+    }
     @media ${Tablet} {
+      top: -130px;
       background-image: url("/images/wave1920.webp");
     }
   }
@@ -73,11 +80,10 @@ export const Contact = styled.div`
 `;
 
 export const Newsletter = styled.div`
-  display: none;
+  display: block;
   grid-column: 1 / 3;
   grid-row: 3 / 3;
   @media ${Mobile} {
-    display: block;
     grid-column: 2 / 3;
     grid-row: 2 / 3;
   }
@@ -144,7 +150,7 @@ export const SocialMediaLinks = styled.div`
 export const SubscriptionField = styled.div`
   max-width: 260px;
   position: relative;
-  /* margin-bottom: 8px; */
+  margin-bottom: 8px;
   @media ${Mobile} {
     margin-top: 0;
     margin-bottom: 10px;

--- a/components/ui/Toast/index.tsx
+++ b/components/ui/Toast/index.tsx
@@ -92,17 +92,14 @@ const ToastComponent = ({
   const isFunction = typeof onClose === "function";
 
   useEffect(() => {
-    // 設置 Toast 消失的計時器
     const hideTimer = setTimeout(() => {
       setIsLeaving(true);
     }, duration);
 
-    // 設置移除 Toast 的計時器（包含動畫時間）
     const removeTimer = setTimeout(() => {
       isFunction && onClose();
     }, duration + animationDuration);
 
-    // 計時器清空，避免記憶體洩漏
     return () => {
       clearTimeout(hideTimer);
       clearTimeout(removeTimer);

--- a/pages/cart/index.tsx
+++ b/pages/cart/index.tsx
@@ -6,6 +6,7 @@ import { CartItem } from "@/components/pages/cart/ProductCard/data";
 import getCarts from "@/utils/api/getCarts";
 import Head from "next/head";
 
+// 讓元件只在 client 端渲染，確保元件不會預先渲染架構
 const Cart = dynamic(() => import("@/components/pages/cart/ProductCard"), {
   loading: () => <Loading />,
 });

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -12,7 +12,7 @@ const HomePage: NextPage = () => {
           content="讓線上輔具租賃流程更加簡單、直觀，讓用戶無縫接軌從選擇到租賃的每一個步驟。"
         />
       </Head>
-      <Home />;
+      <Home />
     </>
   );
 };


### PR DESCRIPTION
相關 PR fix(footer): optimize wave background image scaling #67 

## 問題說明
1. 當瀏覽器寬度大於頁尾波浪背景圖時，會出現變形和顯示異常的問題，如下圖所示。
<img width="755" alt="image" src="https://github.com/user-attachments/assets/6fd8db33-e7fb-42f0-9795-bcf725bb6686" />

2. 手機版使用過大的圖片資源

## 功能說明

修復 footer 波浪背景在響應式縮放時的顯示問題
- Mobile 以上斷點使用 background-size: cover 確保圖片不變形
- Mobile 以下斷點使用 background-size: 100% 100%;，確保圖片完全覆蓋容器寬度不會有空白區域
<img width="737" alt="image" src="https://github.com/user-attachments/assets/3837dcc9-78e0-4080-bf80-b3dc9fed1deb" />

新增兩個斷點（平板、手機）使用的圖片資源
- wave768.webp
- wave375.webp

## 相關檔案
- [components/layout/Footer/styled.tsx](https://github.com/kentrpg/assist-hub/pull/66/files#diff-e71832b6fe3386998f522abb2be6e1a3435c54345b03bfa8b46c187a23adfb78)

## 測試重點
- [ ] 畫面寬度大於 1920 px 是否有正確顯示
- [ ] 確認 Mobile 以下斷點波浪低谷處無背景色透出（確保圖片完全覆蓋容器寬度不會有空白區域）
- [ ] 確認三個斷點有吃到不同圖片資源
- 手機版（<576px）使用 wave375.webp
- 平板版（576px-1279px）使用 wave768.webp
- 桌面版（≥1280px）使用 wave1920.webp

