### PR TITLE
fix(footer): optimize wave background image scaling

### DIFF
--- a/components/layout/Footer/styled.tsx
+++ b/components/layout/Footer/styled.tsx
@@ -29,7 +29,6 @@ export const Wrapper = styled.footer`
     @media ${Mobile} {
       top: -110px;
       background-image: url("/images/wave768.webp");
-      background-size: cover;
     }
     @media ${Tablet} {
       top: -130px;


### PR DESCRIPTION
相關 PR fix(footer): fix wave background display issues in responsive scaling #66 

## 問題說明
圖片在 wave768.webp、wave1920.webp 切換時沒有完美銜接

![#67 before](https://github.com/user-attachments/assets/07ed66cf-f240-4bbc-b931-2b35ed5c580f)

## 功能說明
優化波浪背景圖片在響應式的縮放效果
- 統一設置 `background-size: 100% 100%` 取代原本的 `cover`
- 確保三個斷點的圖片（375/768/1920）能完美銜接

![#67 after](https://github.com/user-attachments/assets/6e5e1a34-269c-4ef4-afae-5fa9b2ea51aa)

## 相關文件
- [components/layout/Footer/styled.tsx](https://github.com/kentrpg/assist-hub/pull/67/files#diff-e71832b6fe3386998f522abb2be6e1a3435c54345b03bfa8b46c187a23adfb78)

## 測試重點
- [ ] 確認三個斷點切換時波浪圖案的銜接順暢