### PR TITLE
refactor(_document): remove redundant title and meta description tags

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -42,8 +42,6 @@ export default class MyDocument extends Document {
       <Html lang="zh-Hant">
         {/* 在這裡添加全域的 meta 標籤、字體或其他標籤 */}
         <Head>
-          <title>RENT4U 輔具租賃網</title>
-          <meta name="description" content="為您打造最適合的輔具商品" />
           <link rel="icon" href="/images/LOGO.webp" />
         </Head>
         <body>


### PR DESCRIPTION
## 背景說明
移除 _document.tsx <Head> 設置的 <title> 和 <meta description>，解決終端機「Warning: <title> should not be used in _document.js's <Head>. https://nextjs.org/docs/messages/no-document-title」錯誤訊息 。

![image](https://github.com/user-attachments/assets/1e1fd974-6be1-4002-9468-4eba8588bff1)

## 功能說明

[官方文件](https://nextjs.org/docs/pages/building-your-application/routing/custom-document) 有提到「_document.tsx 的 <Head> 應用於設置所有頁面共用的 <head> 區塊內容，而不應包含特定頁面的 <title>」。

由於 _document.tsx 僅在伺服器端渲染，無法在客戶端更新，因此不建議在此設置通用的 `<title>`、`<meta description>`，在各自的頁面中動態設置。

## 技術實現
- 這次重構移除 document <title> 和 <meta description>，改為各自頁面個別透過 next/head 動態設置自己的 <title> 和 <meta description>。

## 相關文件

變更檔案
- [pages/_document.tsx](https://github.com/kentrpg/assist-hub/pull/68/files#diff-4aaf885cfc46070419a446e27afeee17f0aacb25a188f74ef7dac690424f8a71)

技術文件
- [NextJS Custom Document](https://nextjs.org/docs/pages/building-your-application/routing/custom-document)