### PR TITLE
refactor(api): resolve auth check request errors and request configur…

### DIFF
--- a/utils/api/auth/check.tsx
+++ b/utils/api/auth/check.tsx
@@ -1,6 +1,6 @@
 import { get_auth_check } from "@/constants/apiPath";
 import { Result } from "@/types/postOrder";
-import { Error } from "@/types/apiRoutes";
+import type { Error } from "@/types/apiRoutes";
 import { catchError } from "@/utils/handleErrors";
 
 export const check = async (token: string): Promise<Result> => {
@@ -12,6 +12,7 @@ export const check = async (token: string): Promise<Result> => {
       Accept: "application/json",
       "Content-Type": "application/json",
     },
+    body: JSON.stringify({}),
   };
 
   const [res, error] = await catchError(fetch(parsedUrl, options));
@@ -33,16 +34,32 @@ export const check = async (token: string): Promise<Result> => {
     };
   }
 
-  const json = await res.json();
-  console.log("Auth check response:", json);
+  try {
+    const json = await res.json();
 
-  return {
-    statusCode: json.statusCode,
-    status: json.status,
-    message: json.message,
-    data: json.data,
-    error: null,
-  };
+    return {
+      statusCode: json.statusCode,
+      status: json.status,
+      message: json.message,
+      data: json.data,
+      error: null,
+    };
+  } catch (parseError) {
+    const errorText = await res.text();
+    console.error("JSON parse error:", errorText, parseError);
+    const unexpectedError: Error = {
+      code: res.status,
+      message: "伺服器忙線中",
+    };
+
+    return {
+      statusCode: res.status,
+      status: false,
+      message: unexpectedError.message,
+      data: undefined,
+      error: unexpectedError,
+    };
+  }
 };
 
 export default check;


### PR DESCRIPTION
## 背景說明
本次更新主要處理 Auth Check API 在發送 POST 請求時遇到的 411 Length Required 錯誤問題，並全面優化了 API 錯誤處理機制，提升系統穩定性和用戶體驗。

*postman 添加 body 空物件的做法，測試還是會遇到 411 Length Required，目前採用加上 body: JSON.stringify({}) 讓瀏覽器自動計算並驗證 Content-Length 方式，部署上去讓其他夥伴測試看看。

## 功能說明
1. 修復 Auth Check API 請求錯誤
- 解決 POST method empty request body 導致的 411 Length Required 錯誤
- 確保 API 請求符合 HTTP/1.1 協議標準
2. 增強錯誤處理機制
- 新增 JSON 解析錯誤處理
- 添加 error log

## 技術實現

**調整 fetch options**
- 為 fetch post method 添加空物件 body: JSON.stringify({})

**新增 try/catch 錯誤處理機制**
- 實作 try/catch 機制捕獲 JSON 解析錯誤
- 使用 res.text() 獲取原始回應內容，便於診斷問題
- 提供預設錯誤訊息「伺服器忙線中」，優化用戶體驗

## 相關文件
- [utils/api/auth/check.tsx](https://github.com/kentrpg/assist-hub/pull/86/files)

## 測試重點
- [ ] 進入 /inquiry 詢問單頁面是否有出現問題跳轉到 500 page