### PR TITLE
fix(navigation): resolve hard navigation errors

### DIFF
--- a/components/layout/Header/index.tsx
+++ b/components/layout/Header/index.tsx
@@ -25,7 +25,7 @@ import {
   DropdownItemButton,
   DropdownItemLink,
 } from "./styled";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useBreakpoint } from "@/hooks/useBreakpoint";
 import { breakpoints } from "@/styles/container";
 import { ImageLink as LogoWrapperDesktop } from "@/components/ui/images";
@@ -42,6 +42,18 @@ const Header = ({ isAuthenticated, isLoading }: HeaderProps) => {
   const [isDropdownToggled, setIsDropdownToggled] = useState(false);
   const { openToast, Toast } = useToast();
 
+  useEffect(() => {
+    const handleRouteChangeStart = () => {
+      setMenuOpen(false);
+    };
+
+    router.events.on("routeChangeStart", handleRouteChangeStart);
+
+    return () => {
+      router.events.off("routeChangeStart", handleRouteChangeStart);
+    };
+  }, [router]);
+
   const triggerButtonRef = useOutsideClick(
     () => setIsDropdownToggled(false),
     true,
@@ -49,10 +61,6 @@ const Header = ({ isAuthenticated, isLoading }: HeaderProps) => {
 
   const toggleMenu = () => {
     setMenuOpen((prevState) => !prevState);
-  };
-
-  const handleNavLinkClick = () => {
-    setMenuOpen(false);
   };
 
   const toggleAccountMenu = () => {
@@ -155,33 +163,17 @@ const Header = ({ isAuthenticated, isLoading }: HeaderProps) => {
           )}
           <NavLinks>
             {!isTablet && (
-              <NavLink
-                href="/"
-                $isActive={router.pathname === "/"}
-                onClick={handleNavLinkClick}
-              >
+              <NavLink href="/" $isActive={router.pathname === "/"}>
                 首頁
               </NavLink>
             )}
-            <NavLink
-              href="/product"
-              $isActive={router.pathname === "/product"}
-              onClick={handleNavLinkClick}
-            >
+            <NavLink href="/product" $isActive={router.pathname === "/product"}>
               所有輔具
             </NavLink>
-            <NavLink
-              href="/faq"
-              onClick={handleNavLinkClick}
-              $isActive={router.pathname === "/faq"}
-            >
+            <NavLink href="/faq" $isActive={router.pathname === "/faq"}>
               常見問題
             </NavLink>
-            <NavLink
-              href="/inquiry"
-              $isActive={router.pathname === "/inquiry"}
-              onClick={handleNavLinkClick}
-            >
+            <NavLink href="/inquiry" $isActive={router.pathname === "/inquiry"}>
               詢問單
             </NavLink>
           </NavLinks>

--- a/components/ui/InquiryBar/index.tsx
+++ b/components/ui/InquiryBar/index.tsx
@@ -32,6 +32,13 @@ const InquiryBar: React.FC = () => {
     .fill(null)
     .map((_, index) => index + inquiryBar.length + 1);
 
+  const handleInquiryBtnClick = () => {
+    if (router.pathname === "/inquiry") {
+      return;
+    }
+    router.push("/inquiry");
+  };
+
   // 如果沒有任何商品，則不顯示 Bar
   if (inquiryBar.length === 0) return null;
 
@@ -71,22 +78,7 @@ const InquiryBar: React.FC = () => {
           </EmptyCircle>
         ))}
       </Products>
-      <Link href={`/inquiry`} passHref>
-        <InquiryBtn
-          onClick={(e) => {
-            e.preventDefault(); // 阻止瀏覽器的默認行為（例如新分頁開啟）
-            if (!e.metaKey && !e.ctrlKey) {
-              // 確保不是通過 `Ctrl` 或 `Cmd` 點擊，然後執行路由跳轉
-              router.push("/inquiry");
-            }
-          }}
-          onContextMenu={(e) => {
-            e.preventDefault(); // 阻止右鍵功能
-          }}
-        >
-          前往詢問單
-        </InquiryBtn>
-      </Link>
+      <InquiryBtn onClick={handleInquiryBtnClick}>前往詢問單</InquiryBtn>
     </BarContainer>
   );
 };

--- a/components/ui/InquiryBar/styled.tsx
+++ b/components/ui/InquiryBar/styled.tsx
@@ -1,6 +1,9 @@
 import styled from "styled-components";
 import { Container1344 } from "@/styles/container";
 import { Tablet, Desktop, Mobile, ExtraLarge } from "@/styles/container";
+import { buttonSizes } from "../buttons/Layout";
+import { ButtonScaleUp } from "@/styles/effect";
+import { PrimaryButton } from "@/components/ui/buttons/Layout";
 
 export const BarContainer = styled(Container1344)`
   display: flex;
@@ -19,9 +22,7 @@ export const BarContainer = styled(Container1344)`
   transform: translateX(-50%);
   background-color: white;
   z-index: 1000;
-  transition:
-    transform 0.3s ease,
-    bottom 0.3s ease;
+  transition: transform 0.3s ease, bottom 0.3s ease;
   @media ${Mobile} {
     padding: 20px 24px;
   }
@@ -80,24 +81,15 @@ export const Img = styled.img`
   }
 `;
 
-export const InquiryBtn = styled.button`
-  white-space: nowrap;
-  border-radius: 30px;
-  background-color: #103f99;
-  color: white;
-  padding: 10px 40px;
-  font-size: 18px;
-  height: 47px;
-  font-weight: 500;
-  transition:
-    background-color 0.3s ease,
-    box-shadow 0.3s ease,
+export const InquiryBtn = styled(PrimaryButton)`
+  ${buttonSizes.xlarge};
+  transition: background-color 0.3s ease, box-shadow 0.3s ease,
     transform 0.3s ease;
 
   &:hover {
-    background-color: #0b2c6b;
+    background-color: ${({ theme }) => theme.colors.primaryHover};
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
-    transform: scale(1.1);
+    ${ButtonScaleUp};
   }
 `;
 
@@ -109,9 +101,7 @@ export const IconWrapper = styled.div`
   background-color: #103f99;
   width: 24px;
   height: 24px;
-  transition:
-    background-color 0.3s ease,
-    box-shadow 0.2s ease,
+  transition: background-color 0.3s ease, box-shadow 0.2s ease,
     transform 0.2s ease;
 
   &:hover {


### PR DESCRIPTION
## 背景說明

跳轉到 inquiry page 遇到 nextJS error：`Uncaught (in promise) Error: Invariant: attempted to hard navigate to the same URL`。

<img width="644" alt="image" src="https://github.com/user-attachments/assets/3e1e1d31-0255-458a-a5d5-61df8d4abca3" />

目標 URL 與當前 URL 相同時，next 避免無限循環會觸發 handleHardNavigation，會透過 [window.location.href = url](https://github.com/vercel/next.js/blob/c6ab3d53694dd3e692daa433449707cba3ea9568/packages/next/src/shared/lib/router/router.ts#L635C3-L635C29) 來執行 hard navigation 強制對 url 發送新的請求。

## 問題排查
> 從當前跳轉到 inquiry 頁面的兩個地方進行排查

**1. Header component**
- 使用 onClick 處理 set state function 關閉漢堡選單
```tsx
<NavLink 
    href="/"
    $isActive={router.pathname === "/"}
    onClick={handleNavLinkClick}
>
```

根據 [next/link source code](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/link.tsx)，Next.js 會在執行 onClick callback 之後才處理內部的導航邏輯，因此評估 setMenuOpen(false) 不會直接影響跳轉。
- 即使是已經在 inquiry 頁面情況下，正常操作透過 next/link href 再次跳轉到相同頁面也不會有問題
    - Next.js 的 next/link 在跳轉到相同 URL 時，默認會觸發 shallow 導航（不重新執行 getServerSideProps），但若手動調用 router.push，則可能觸發錯誤。

**2. InquiryBar component Link nested button**
- Link  設置無效 passHref
- href 與 router.push 的路由相同
- 子層設置 button
```tsx
<Link href={`/inquiry`} passHref>
    <InquiryBtn></InquiryBtn>
</Link>
```

根據 [HTML 規範](https://html.spec.whatwg.org/multipage/form-elements.html#the-button-element) button 不支援 href attributes，即使強行傳遞 href，button 也不會使用它，導致 passHref 失效。

根據 [next/link source code](https://github.com/vercel/next.js/blob/5daf2ee572aa106cf143f421cf7bd2e0c742eb36/packages/next/src/client/link.tsx#L591-L597) 對 childProps 型別宣告為 React.MouseEventHandler<HTMLAnchorElement>，推斷內層不適合設置 button。

判斷當前架構在 nested element onClick 有設置 e.preventDefault() 情況下，因為 next/link href 與 router.push 路由相同，可能造成重複跳轉的非預期結果，進而導致 `Error: Invariant: attempted to hard navigate to the same URL`。

## 功能說明

**InquiryBar 添加判斷式**
- onClick 添加 `router.pathname === "/inquiry"` 判斷式，避免發生重複跳轉

**簡化 InquiryBar 架構**
- 移除父層 next/link 架構，簡化 event handle
   - button 不需預防點右鍵以及開啟新視窗導致 redux store 重置。
- 重構 InquiryBtn component 樣式，改用繼承方式來設置元件化樣式

**Header next/link 優化：useEffect event listener 取代 NavLink onClick**
- 改為 useEffect 監聽 `router.events.on(\"routeChangeStart\")` 移除 next/link onClick
   - 改善跳轉時的狀態管理，確保所有跳轉行為（如 router.push）皆可觸發選單關閉。

## 相關文件

相關元件
- [components/ui/InquiryBar/index.tsx](https://github.com/kentrpg/assist-hub/pull/87/files#diff-173e857aae17136b87a72673b0ce4b5172ef9444095b1d2d0482378c6fef4f7c)
- [components/layout/Header/index.tsx](https://github.com/kentrpg/assist-hub/pull/87/files#diff-3b18d7c671dbe87419f8b175764ff7bb6c15204fbdaba3109660fa4a9d02a8c6)

參考文獻
- [Next.js Link Component Source Code](https://github.com/vercel/next.js/blob/5daf2ee572aa106cf143f421cf7bd2e0c742eb36/packages/next/src/client/link.tsx#L4)
- [Next.js Router Source Code](https://github.com/vercel/next.js/blob/canary/packages/next/src/shared/lib/router/router.ts)

## 測試重點
- [ ] 確認多次點擊 InquiryBtn「前往詢問單」、header「詢問單」都有正確跳轉
- 不會觸發 Invariant: attempted to hard navigate to the same URL